### PR TITLE
Expose core modules via public re-exports

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,24 @@
+# Cursor Project Rules
+
+[available_instructions]
+pytest_naming: |
+  Use pytest discovery configuration from `pyproject.toml`:
+  - test paths: `tests`
+  - test files: `it_*.py`, `test_*.py`
+  - test classes: `Describe[A-Z]*`
+  - test functions: `it_*`
+  Follow existing tests that use classes like `DescribeSomething` with methods named `it_*`.
+
+public_api_reexports: |
+  `valid8r` top-level must re-export:
+  - modules: `parsers`, `validators`, `combinators`, and `prompt` (with `ask` exposed in `valid8r.prompt`).
+  - types: `Maybe` from `valid8r.core.maybe`.
+  Maintain backward compatibility for deep imports.
+
+run_tests_locally: |
+  In constrained environments without pytest installed, use a Python smoke test importing:
+  `from valid8r import parsers, validators, prompt, Maybe` and assert `prompt.ask` is callable.
+
+[default]
+- When adding tests, ensure names match the `Describe*` / `it_*` style so they are discovered.
+- Avoid changing unrelated formatting; match repo code style and ruff rules.

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -1,27 +1,26 @@
 from __future__ import annotations
 
 
-def test_import_core_modules_from_top_level() -> None:
-    # Feature: Public API re-exports
-    # Scenario: Import core modules from top-level
-    from valid8r import parsers, validators, prompt
+class DescribePublicApi:
+    def it_imports_core_modules_from_top_level(self) -> None:
+        # Feature: Public API re-exports
+        # Scenario: Import core modules from top-level
+        from valid8r import parsers, validators, prompt
 
-    assert parsers is not None
-    assert validators is not None
-    assert prompt is not None
+        assert parsers is not None
+        assert validators is not None
+        assert prompt is not None
 
+    def it_imports_maybe_from_top_level(self) -> None:
+        # Scenario: Import Maybe types from top-level
+        from valid8r import Maybe
+        from valid8r.core.maybe import Maybe as CoreMaybe
 
-def test_import_maybe_from_top_level() -> None:
-    # Scenario: Import Maybe types from top-level
-    from valid8r import Maybe
-    from valid8r.core.maybe import Maybe as CoreMaybe
+        assert Maybe is CoreMaybe
 
-    assert Maybe is CoreMaybe
+    def it_exposes_prompt_ask_at_top_level(self) -> None:
+        # Scenario: Top-level ask function
+        from valid8r import prompt
 
-
-def test_top_level_prompt_ask_callable() -> None:
-    # Scenario: Top-level ask function
-    from valid8r import prompt
-
-    assert hasattr(prompt, 'ask')
-    assert callable(prompt.ask)
+        assert hasattr(prompt, 'ask')
+        assert callable(prompt.ask)

--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+
+def test_import_core_modules_from_top_level() -> None:
+    # Feature: Public API re-exports
+    # Scenario: Import core modules from top-level
+    from valid8r import parsers, validators, prompt
+
+    assert parsers is not None
+    assert validators is not None
+    assert prompt is not None
+
+
+def test_import_maybe_from_top_level() -> None:
+    # Scenario: Import Maybe types from top-level
+    from valid8r import Maybe
+    from valid8r.core.maybe import Maybe as CoreMaybe
+
+    assert Maybe is CoreMaybe
+
+
+def test_top_level_prompt_ask_callable() -> None:
+    # Scenario: Top-level ask function
+    from valid8r import prompt
+
+    assert hasattr(prompt, 'ask')
+    assert callable(prompt.ask)

--- a/valid8r/__init__.py
+++ b/valid8r/__init__.py
@@ -4,3 +4,20 @@
 from __future__ import annotations
 
 __version__ = '0.1.0'
+
+# Public API re-exports for concise imports
+# Modules
+from . import prompt
+from .core import combinators, parsers, validators
+
+# Types
+from .core.maybe import Maybe
+
+__all__ = [
+    '__version__',
+    'parsers',
+    'validators',
+    'combinators',
+    'prompt',
+    'Maybe',
+]

--- a/valid8r/prompt/__init__.py
+++ b/valid8r/prompt/__init__.py
@@ -2,3 +2,7 @@
 """Input prompting functionality for command-line applications."""
 
 from __future__ import annotations
+
+from .basic import ask
+
+__all__ = ['ask']


### PR DESCRIPTION
Add public re-exports to the `valid8r` package root to enable concise imports for users.

---
<a href="https://cursor.com/background-agent?bcId=bc-4b6bba00-b6c3-4ac5-87c5-c71f1e99bafb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4b6bba00-b6c3-4ac5-87c5-c71f1e99bafb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

