### PR TITLE
Fix readme parser name and imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ pip install valid8r
 ## Quick Start
 
 ```python
-from valid8r import parsers, validators, prompt
+from valid8r import (
+    parsers,
+    prompt,
+    validators,
+)
 
 # Simple validation
 age = prompt.ask(
@@ -35,7 +39,10 @@ print(f"Your age is {age}")
 Valid8r includes testing utilities to help you verify your validation logic:
 
 ```python
-from valid8r.testing import MockInputContext, assert_maybe_success
+from valid8r.testing import (
+    MockInputContext,
+    assert_maybe_success,
+)
 
 # Test prompts with mock input
 with MockInputContext(["yes"]):

--- a/README.md
+++ b/README.md
@@ -18,16 +18,12 @@ pip install valid8r
 ## Quick Start
 
 ```python
-from valid8r import (
-    parsers,
-    prompt,
-    validators, 
-)
+from valid8r import parsers, validators, prompt
 
 # Simple validation
 age = prompt.ask(
     "Enter your age: ",
-    parser=parsers.int_parser,
+    parser=parsers.parse_int,
     validator=validators.minimum(0) & validators.maximum(120)
 )
 


### PR DESCRIPTION
Update README Quick Start to use `parsers.parse_int` and correct import statement to match public API.

---
<a href="https://cursor.com/background-agent?bcId=bc-6958d91f-4958-4fdf-8857-55ba724f846c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6958d91f-4958-4fdf-8857-55ba724f846c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

