### PR TITLE
update to latest deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,35 +18,35 @@ classifiers = [
 packages = [{include = "valid8r"}]
 
 [tool.poetry.dependencies]
-python = ">=3.11"
+python = ">=3.11,<4.0"
 # No external dependencies for core functionality
 
 [tool.poetry.group.dev.dependencies]
 livereload = "^2.7.1"
-mypy = "^1.15.0"
+mypy = "^1.17.1"
 
 [tool.poetry.group.lint.dependencies]
 isort = "^6.0.1"
-ruff = "^0.9.9"
+ruff = "^0.12.8"
 
 [tool.poetry.group.docs.dependencies]
 myst-parser = "^4.0.1"
 sphinx = "^8.2.3"
 sphinx-autoapi = "^3.6.0"
-sphinx-autodoc-typehints = "^3.1.0"
+sphinx-autodoc-typehints = "^3.2.0"
 sphinx-copybutton = "^0.5.2"
 sphinx-rtd-theme = "^3.0.2"
 
 
 [tool.poetry.group.test.dependencies]
-behave = "^1.2.6"
-coverage = "^7.6.12"
-pytest = "^8.3.5"
+behave = "^1.3.0"
+coverage = "^7.10.2"
+pytest = "^8.4.1"
 pytest-bdd = "^8.1.0"
-pytest-cov = "^6.0.0"
-pytest-mock = "^3.14.0"
+pytest-cov = "^6.2.1"
+pytest-mock = "^3.14.1"
 pytest-sugar = "^1.0.0"
-tox = "^4.24.1"
+tox = "^4.28.4"
 
 [tool.poetry.scripts]
 docs-build = "scripts.docs:build"


### PR DESCRIPTION
Update Python version constraint to "\<4.0" to ensure compatibility with
future Python releases. Upgrade development dependencies: - mypy to
"\^1.17.1" - ruff to "\^0.12.8" - sphinx-autodoc-typehints to
"\^3.2.0" - behave to "\^1.3.0" - coverage to "\^7.10.2" - pytest to
"\^8.4.1" - pytest-cov to "\^6.2.1" - pytest-mock to "\^3.14.1" - tox to
"\^4.28.4"

These updates ensure the project remains up-to-date with the latest
features and bug fixes in these tools.
