### PR TITLE
Parse uuid strings with version validation

### DIFF
--- a/tests/unit/test_uuid_parser.py
+++ b/tests/unit/test_uuid_parser.py
@@ -1,0 +1,38 @@
+import re
+from uuid import UUID
+
+import pytest
+
+from valid8r.core.maybe import Success, Failure
+from valid8r.core.parsers import parse_uuid
+
+
+def make_uuid(version: int) -> str:
+    # Generate a syntactically valid UUID for the given version.
+    # UUID format: 8-4-4-4-12 hex; set variant nibble to 'a' (RFC 4122) and version nibble accordingly.
+    seg1 = '123e4567'
+    seg2 = 'e89b'
+    seg3 = f'{version:x}234'  # version nibble + 3 arbitrary hex
+    seg4 = 'a234'  # variant nibble in [89ab] + 3 arbitrary hex
+    seg5 = '1234567890ab'
+    return f'{seg1}-{seg2}-{seg3}-{seg4}-{seg5}'
+
+
+@pytest.mark.parametrize('v', [1, 3, 4, 5, 7])
+def test_parse_valid_uuid_versions(v: int) -> None:
+    u = make_uuid(v)
+    match parse_uuid(u, version=v):
+        case Success(value):
+            assert isinstance(value, UUID)
+            assert value.version == v
+        case Failure(error):  # pragma: no cover - easier debug
+            pytest.fail(f'Unexpected failure: {error}')
+
+
+def test_reject_wrong_version_when_strict() -> None:
+    v1 = make_uuid(1)
+    match parse_uuid(v1, version=4, strict=True):
+        case Success(value):
+            pytest.fail(f'Unexpected success: {value}')
+        case Failure(error):
+            assert 'expected v4' in error and 'got v1' in error


### PR DESCRIPTION
Implement `parse_uuid` to support parsing UUIDs (v1, v3, v4, v5, v7) with optional version validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-44fc6432-748a-45c8-810b-5a0387a0abcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44fc6432-748a-45c8-810b-5a0387a0abcf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

