### PR TITLE
Parse ip addresses and cidr networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,33 @@ age = prompt.ask(
 print(f"Your age is {age}")
 ```
 
+### IP parsing helpers
+
+```python
+from valid8r.core.maybe import Success, Failure
+from valid8r.core import parsers
+
+# IPv4 / IPv6 / generic IP
+for text in ["192.168.0.1", "::1", " 10.0.0.1 "]:
+    match parsers.parse_ip(text):
+        case Success(addr):
+            print("Parsed:", addr)
+        case Failure(err):
+            print("Error:", err)
+
+# CIDR (strict by default)
+match parsers.parse_cidr("10.0.0.0/8"):
+    case Success(net):
+        print("Network:", net)  # 10.0.0.0/8
+    case Failure(err):
+        print("Error:", err)
+
+# Non-strict masks host bits
+match parsers.parse_cidr("10.0.0.1/24", strict=False):
+    case Success(net):
+        assert str(net) == "10.0.0.0/24"
+```
+
 ## Testing Support
 
 Valid8r includes testing utilities to help you verify your validation logic:

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -727,3 +727,34 @@ Matching Multiple Results
                return f"Invalid x-coordinate: {error}"
            case (_, Failure(error)):
                return f"Invalid y-coordinate: {error}"
+
+.. py:function:: valid8r.core.parsers.parse_ipv4(text)
+
+   Parse a string to an IPv4Address. Surrounding whitespace is ignored.
+
+   :param text: Input string
+   :return: Maybe[IPv4Address] with deterministic errors: "value must be a string", "value is empty", "not a valid IPv4 address"
+
+.. py:function:: valid8r.core.parsers.parse_ipv6(text)
+
+   Parse a string to an IPv6Address. Surrounding whitespace is ignored and output is canonicalized.
+
+   :param text: Input string
+   :return: Maybe[IPv6Address] with deterministic errors: "value must be a string", "value is empty", "not a valid IPv6 address"
+
+.. py:function:: valid8r.core.parsers.parse_ip(text)
+
+   Parse a string to an IP address, accepting either IPv4 or IPv6. Surrounding whitespace is ignored.
+
+   :param text: Input string
+   :return: Maybe[IPv4Address | IPv6Address] with deterministic errors: "value must be a string", "value is empty", "not a valid IP address"
+
+.. py:function:: valid8r.core.parsers.parse_cidr(text, *, strict=True)
+
+   Parse a CIDR network string to IPv4Network or IPv6Network using ``ipaddress.ip_network``.
+
+   ``strict=True`` (default) rejects inputs with host bits set; use ``strict=False`` to mask host bits.
+
+   :param text: Input string
+   :param strict: Whether to reject host bits
+   :return: Maybe[IPv4Network | IPv6Network] with deterministic errors: "value must be a string", "value is empty", "has host bits set" (when strict), "not a valid network"

--- a/docs/autoapi/valid8r/core/index.rst
+++ b/docs/autoapi/valid8r/core/index.rst
@@ -21,3 +21,69 @@ Submodules
    /autoapi/valid8r/core/validators/index
 
 
+Functions
+---------
+
+.. autoapisummary::
+
+   valid8r.core.parse_cidr
+   valid8r.core.parse_ip
+   valid8r.core.parse_ipv4
+   valid8r.core.parse_ipv6
+
+
+Package Contents
+----------------
+
+.. py:function:: parse_cidr(text, *, strict = True)
+
+   Parse a CIDR network string (IPv4 or IPv6).
+
+   Uses ipaddress.ip_network under the hood. By default ``strict=True``
+   so host bits set will fail. With ``strict=False``, host bits are masked.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - has host bits set (when strict and host bits are present)
+   - not a valid network (all other parsing failures)
+
+
+.. py:function:: parse_ip(text)
+
+   Parse a string as either an IPv4 or IPv6 address.
+
+   Trims surrounding whitespace only.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - not a valid IP address
+
+
+.. py:function:: parse_ipv4(text)
+
+   Parse an IPv4 address string.
+
+   Trims surrounding whitespace only. Returns Success with a concrete
+   IPv4Address on success, or Failure with a deterministic error message.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - not a valid IPv4 address
+
+
+.. py:function:: parse_ipv6(text)
+
+   Parse an IPv6 address string.
+
+   Trims surrounding whitespace only. Returns Success with a concrete
+   IPv6Address on success, or Failure with a deterministic error message.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - not a valid IPv6 address
+
+

--- a/docs/autoapi/valid8r/core/parsers/index.rst
+++ b/docs/autoapi/valid8r/core/parsers/index.rst
@@ -44,6 +44,10 @@ Functions
    valid8r.core.parsers.make_parser
    valid8r.core.parsers.validated_parser
    valid8r.core.parsers.parse_uuid
+   valid8r.core.parsers.parse_ipv4
+   valid8r.core.parsers.parse_ipv6
+   valid8r.core.parsers.parse_ip
+   valid8r.core.parsers.parse_cidr
 
 
 Module Contents
@@ -252,5 +256,57 @@ Module Contents
 
    :returns: Success with a UUID object or Failure with an error message.
    :rtype: Maybe[UUID]
+
+
+.. py:function:: parse_ipv4(text)
+
+   Parse an IPv4 address string.
+
+   Trims surrounding whitespace only. Returns Success with a concrete
+   IPv4Address on success, or Failure with a deterministic error message.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - not a valid IPv4 address
+
+
+.. py:function:: parse_ipv6(text)
+
+   Parse an IPv6 address string.
+
+   Trims surrounding whitespace only. Returns Success with a concrete
+   IPv6Address on success, or Failure with a deterministic error message.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - not a valid IPv6 address
+
+
+.. py:function:: parse_ip(text)
+
+   Parse a string as either an IPv4 or IPv6 address.
+
+   Trims surrounding whitespace only.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - not a valid IP address
+
+
+.. py:function:: parse_cidr(text, *, strict = True)
+
+   Parse a CIDR network string (IPv4 or IPv6).
+
+   Uses ipaddress.ip_network under the hood. By default ``strict=True``
+   so host bits set will fail. With ``strict=False``, host bits are masked.
+
+   Error messages:
+   - value must be a string
+   - value is empty
+   - has host bits set (when strict and host bits are present)
+   - not a valid network (all other parsing failures)
 
 

--- a/docs/development/changelog.rst
+++ b/docs/development/changelog.rst
@@ -12,6 +12,12 @@ and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0
 Added
 ~~~~~
 
+- IP parsing helpers built on ``ipaddress``:
+  - ``parse_ipv4``, ``parse_ipv6``, ``parse_ip``, ``parse_cidr``
+- Deterministic error messages and whitespace normalization
+- Unit tests covering IPv4/IPv6/CIDR success and failure scenarios
+- Documentation updates in User Guide, API reference, and examples
+
 - Initial implementation of the Maybe monad
 - Core parsers for various data types
 - Core validators with operator overloading

--- a/docs/examples/basic_example.rst
+++ b/docs/examples/basic_example.rst
@@ -454,4 +454,33 @@ Valid8r also handles validation of complex data structures:
 
    process_user(user)
 
+IP Address parsing
+------------------
+
+.. code-block:: python
+
+   from valid8r.core.maybe import Success, Failure
+   from valid8r import parsers
+
+   # IPv4
+   match parsers.parse_ipv4("8.8.8.8"):
+       case Success(addr):
+           print(addr)
+       case Failure(err):
+           print("Error:", err)
+
+   # IPv6
+   match parsers.parse_ipv6("2001:db8::1"):
+       case Success(addr):
+           print(addr)
+       case Failure(err):
+           print("Error:", err)
+
+   # CIDR (non-strict)
+   match parsers.parse_cidr("10.0.0.1/24", strict=False):
+       case Success(net):
+           print(net)  # 10.0.0.0/24
+       case Failure(err):
+           print("Error:", err)
+
 These examples provide a solid foundation for understanding how to use Valid8r effectively in your applications. In the next sections, we'll explore more advanced usage patterns.

--- a/tests/unit/test_ip_parsers.py
+++ b/tests/unit/test_ip_parsers.py
@@ -170,7 +170,7 @@ class DescribeIpParsers:
                 pytest.fail(f'unexpected failure: {err}')
 
     def it_ignores_surrounding_whitespace(self) -> None:
-        match parse_cidr('  172.16.0.1/16  '):
+        match parse_cidr('  172.16.0.0/16  '):
             case Success(value):
                 assert isinstance(value, ip.IPv4Network)
                 assert str(value) == '172.16.0.0/16'

--- a/tests/unit/test_ip_parsers.py
+++ b/tests/unit/test_ip_parsers.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import ipaddress as ip
+
+import pytest
+
+from valid8r.core.maybe import (
+    Failure,
+    Success,
+)
+from valid8r.core.parsers import (
+    parse_cidr,
+    parse_ip,
+    parse_ipv4,
+    parse_ipv6,
+)
+
+
+class DescribeIpParsers:
+    @pytest.mark.parametrize(
+        ('text', 'normalized'),
+        [
+            pytest.param('192.168.0.1', '192.168.0.1', id='v4-valid-192-168-0-1'),
+            pytest.param('8.8.8.8', '8.8.8.8', id='v4-valid-8-8-8-8'),
+            pytest.param(' 10.0.0.254 ', '10.0.0.254', id='v4-trim-whitespace'),
+        ],
+    )
+    def it_parses_ipv4_success(self, text: str, normalized: str) -> None:
+        match parse_ipv4(text):
+            case Success(value):
+                assert isinstance(value, ip.IPv4Address)
+                assert str(value) == normalized
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    @pytest.mark.parametrize(
+        ('text', 'message'),
+        [
+            pytest.param('256.0.0.1', 'not a valid IPv4 address', id='v4-invalid-octet-range'),
+            pytest.param('192.168.0', 'not a valid IPv4 address', id='v4-invalid-too-few-octets'),
+            pytest.param('192.168.0.1.1', 'not a valid IPv4 address', id='v4-invalid-too-many-octets'),
+            pytest.param('abc', 'not a valid IPv4 address', id='v4-invalid-alpha'),
+            pytest.param('', 'value is empty', id='v4-empty'),
+            pytest.param(None, 'value must be a string', id='v4-wrong-type'),
+        ],
+    )
+    def it_rejects_invalid_ipv4(self, text: object, message: str) -> None:
+        match parse_ipv4(text):  # type: ignore[arg-type]
+            case Success(value):
+                pytest.fail(f'unexpected success: {value}')
+            case Failure(err):
+                assert message in err
+
+    @pytest.mark.parametrize(
+        ('text', 'normalized'),
+        [
+            pytest.param('::1', '::1', id='v6-loopback'),
+            pytest.param('2001:db8::1', '2001:db8::1', id='v6-doc-prefix'),
+            pytest.param('  FE80::1  ', 'fe80::1', id='v6-trim-and-lowercase'),
+            pytest.param('2001:db8:0:0:0:0:2:1', '2001:db8::2:1', id='v6-compress'),
+        ],
+    )
+    def it_parses_ipv6_success(self, text: str, normalized: str) -> None:
+        match parse_ipv6(text):
+            case Success(value):
+                assert isinstance(value, ip.IPv6Address)
+                assert str(value) == normalized
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    @pytest.mark.parametrize(
+        'text',
+        [
+            pytest.param('2001:::1', id='v6-invalid-triple-colon'),
+            pytest.param('::ffff:999.1.1.1', id='v6-invalid-embedded-v4'),
+            pytest.param('fe80::1%eth0', id='v6-scope-id'),
+            pytest.param('abc', id='v6-alpha'),
+        ],
+    )
+    def it_rejects_invalid_ipv6(self, text: str) -> None:
+        match parse_ipv6(text):
+            case Success(value):
+                pytest.fail(f'unexpected success: {value}')
+            case Failure(err):
+                assert 'not a valid IPv6 address' in err
+
+    @pytest.mark.parametrize(
+        ('text', 'kind', 'normalized'),
+        [
+            pytest.param('127.0.0.1', ip.IPv4Address, '127.0.0.1', id='ip-v4'),
+            pytest.param('::1', ip.IPv6Address, '::1', id='ip-v6'),
+        ],
+    )
+    def it_parses_generic_ip(self, text: str, kind: type, normalized: str) -> None:
+        match parse_ip(text):
+            case Success(value):
+                assert isinstance(value, kind)
+                assert str(value) == normalized
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    def it_rejects_generic_non_ip(self) -> None:
+        match parse_ip('hostname.local'):
+            case Success(value):
+                pytest.fail(f'unexpected success: {value}')
+            case Failure(err):
+                assert 'not a valid IP address' in err
+
+    @pytest.mark.parametrize(
+        ('text', 'normalized'),
+        [
+            pytest.param('10.0.0.0/8', '10.0.0.0/8', id='cidr-v4-strict-8'),
+            pytest.param('192.168.1.0/24', '192.168.1.0/24', id='cidr-v4-strict-24'),
+            pytest.param('0.0.0.0/0', '0.0.0.0/0', id='cidr-v4-strict-0'),
+        ],
+    )
+    def it_parses_ipv4_cidr_strict(self, text: str, normalized: str) -> None:
+        match parse_cidr(text):
+            case Success(value):
+                assert isinstance(value, ip.IPv4Network)
+                assert str(value) == normalized
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    @pytest.mark.parametrize(
+        ('text', 'normalized'),
+        [
+            pytest.param('2001:db8::/32', '2001:db8::/32', id='cidr-v6-strict-32'),
+            pytest.param('::/0', '::/0', id='cidr-v6-strict-0'),
+            pytest.param('2001:db8:abcd::/48', '2001:db8:abcd::/48', id='cidr-v6-strict-48'),
+        ],
+    )
+    def it_parses_ipv6_cidr_strict(self, text: str, normalized: str) -> None:
+        match parse_cidr(text):
+            case Success(value):
+                assert isinstance(value, ip.IPv6Network)
+                assert str(value) == normalized
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    @pytest.mark.parametrize(
+        'text',
+        [
+            pytest.param('10.0.0.0/33', id='cidr-v4-prefix-too-large'),
+            pytest.param('2001:db8::/129', id='cidr-v6-prefix-too-large'),
+            pytest.param('192.168.1.0/-1', id='cidr-negative-prefix'),
+            pytest.param('192.168.1.0/x', id='cidr-non-numeric-prefix'),
+        ],
+    )
+    def it_rejects_cidr_invalid_prefix(self, text: str) -> None:
+        match parse_cidr(text):
+            case Success(value):
+                pytest.fail(f'unexpected success: {value}')
+            case Failure(err):
+                assert 'not a valid network' in err
+
+    def it_rejects_cidr_with_host_bits_strict(self) -> None:
+        match parse_cidr('10.0.0.1/24'):
+            case Success(value):
+                pytest.fail(f'unexpected success: {value}')
+            case Failure(err):
+                assert 'has host bits set' in err
+
+    def it_masks_host_bits_when_non_strict(self) -> None:
+        match parse_cidr('10.0.0.1/24', strict=False):
+            case Success(value):
+                assert isinstance(value, ip.IPv4Network)
+                assert str(value) == '10.0.0.0/24'
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    def it_ignores_surrounding_whitespace(self) -> None:
+        match parse_cidr('  172.16.0.1/16  '):
+            case Success(value):
+                assert isinstance(value, ip.IPv4Network)
+                assert str(value) == '172.16.0.0/16'
+            case Failure(err):
+                pytest.fail(f'unexpected failure: {err}')
+
+    @pytest.mark.parametrize(
+        'text',
+        [
+            pytest.param('fe80::1%eth0', id='reject-scope-id'),
+            pytest.param('http://192.168.0.1', id='reject-url'),
+        ],
+    )
+    def it_rejects_non_pure_addresses(self, text: str) -> None:
+        match parse_ip(text):
+            case Success(value):
+                pytest.fail(f'unexpected success: {value}')
+            case Failure(err):
+                assert 'not a valid IP address' in err

--- a/valid8r/core/__init__.py
+++ b/valid8r/core/__init__.py
@@ -2,3 +2,18 @@
 """Core validation components."""
 
 from __future__ import annotations
+
+from valid8r.core.parsers import (
+    parse_cidr,
+    parse_ip,
+    parse_ipv4,
+    parse_ipv6,
+)
+
+__all__ = [
+    # existing exports may be defined elsewhere; explicitly expose IP helpers
+    'parse_ipv4',
+    'parse_ipv6',
+    'parse_ip',
+    'parse_cidr',
+]

--- a/valid8r/core/parsers.py
+++ b/valid8r/core/parsers.py
@@ -708,6 +708,10 @@ def parse_ipv6(text: str) -> Maybe[IPv6Address]:
     if s == '':
         return Maybe.failure('value is empty')
 
+    # Explicitly reject scope IDs like %eth0
+    if '%' in s:
+        return Maybe.failure('not a valid IPv6 address')
+
     try:
         addr = ip_address(s)
     except ValueError:
@@ -736,6 +740,10 @@ def parse_ip(text: str) -> Maybe[IPv4Address | IPv6Address]:
     s = text.strip()
     if s == '':
         return Maybe.failure('value is empty')
+
+    # Reject non-address forms such as IPv6 scope IDs or URLs
+    if '%' in s or '://' in s:
+        return Maybe.failure('not a valid IP address')
 
     try:
         addr = ip_address(s)

--- a/valid8r/core/parsers.py
+++ b/valid8r/core/parsers.py
@@ -24,6 +24,14 @@ from valid8r.core.maybe import (
 from decimal import Decimal, InvalidOperation
 from uuid import UUID
 import uuid_utils as uuidu
+from ipaddress import (
+    IPv4Address,
+    IPv4Network,
+    IPv6Address,
+    IPv6Network,
+    ip_address,
+    ip_network,
+)
 
 T = TypeVar('T')
 K = TypeVar('K')
@@ -650,3 +658,125 @@ def parse_uuid(text: str, version: int | None = None, strict: bool = True) -> Ma
     except Exception:  # noqa: BLE001
         # This should not happen if uuid-utils succeeded, but guard anyway
         return Maybe.failure('Input must be a valid UUID')
+
+
+def parse_ipv4(text: str) -> Maybe[IPv4Address]:
+    """Parse an IPv4 address string.
+
+    Trims surrounding whitespace only. Returns Success with a concrete
+    IPv4Address on success, or Failure with a deterministic error message.
+
+    Error messages:
+    - value must be a string
+    - value is empty
+    - not a valid IPv4 address
+    """
+    if not isinstance(text, str):
+        return Maybe.failure('value must be a string')
+
+    s = text.strip()
+    if s == '':
+        return Maybe.failure('value is empty')
+
+    try:
+        addr = ip_address(s)
+    except ValueError:
+        return Maybe.failure('not a valid IPv4 address')
+
+    if isinstance(addr, IPv4Address):
+        return Maybe.success(addr)
+
+    return Maybe.failure('not a valid IPv4 address')
+
+
+
+def parse_ipv6(text: str) -> Maybe[IPv6Address]:
+    """Parse an IPv6 address string.
+
+    Trims surrounding whitespace only. Returns Success with a concrete
+    IPv6Address on success, or Failure with a deterministic error message.
+
+    Error messages:
+    - value must be a string
+    - value is empty
+    - not a valid IPv6 address
+    """
+    if not isinstance(text, str):
+        return Maybe.failure('value must be a string')
+
+    s = text.strip()
+    if s == '':
+        return Maybe.failure('value is empty')
+
+    try:
+        addr = ip_address(s)
+    except ValueError:
+        return Maybe.failure('not a valid IPv6 address')
+
+    if isinstance(addr, IPv6Address):
+        return Maybe.success(addr)
+
+    return Maybe.failure('not a valid IPv6 address')
+
+
+
+def parse_ip(text: str) -> Maybe[IPv4Address | IPv6Address]:
+    """Parse a string as either an IPv4 or IPv6 address.
+
+    Trims surrounding whitespace only.
+
+    Error messages:
+    - value must be a string
+    - value is empty
+    - not a valid IP address
+    """
+    if not isinstance(text, str):
+        return Maybe.failure('value must be a string')
+
+    s = text.strip()
+    if s == '':
+        return Maybe.failure('value is empty')
+
+    try:
+        addr = ip_address(s)
+    except ValueError:
+        return Maybe.failure('not a valid IP address')
+
+    if isinstance(addr, (IPv4Address, IPv6Address)):
+        return Maybe.success(addr)
+
+    return Maybe.failure('not a valid IP address')
+
+
+
+def parse_cidr(text: str, *, strict: bool = True) -> Maybe[IPv4Network | IPv6Network]:
+    """Parse a CIDR network string (IPv4 or IPv6).
+
+    Uses ipaddress.ip_network under the hood. By default ``strict=True``
+    so host bits set will fail. With ``strict=False``, host bits are masked.
+
+    Error messages:
+    - value must be a string
+    - value is empty
+    - has host bits set (when strict and host bits are present)
+    - not a valid network (all other parsing failures)
+    """
+    if not isinstance(text, str):
+        return Maybe.failure('value must be a string')
+
+    s = text.strip()
+    if s == '':
+        return Maybe.failure('value is empty')
+
+    try:
+        net = ip_network(s, strict=strict)
+    except ValueError as exc:
+        msg = str(exc)
+        if 'has host bits set' in msg:
+            return Maybe.failure('has host bits set')
+        return Maybe.failure('not a valid network')
+
+    if isinstance(net, (IPv4Network, IPv6Network)):
+        return Maybe.success(net)
+
+    return Maybe.failure('not a valid network')


### PR DESCRIPTION
Add IP address and CIDR parsing helpers (`parse_ipv4`, `parse_ipv6`, `parse_ip`, `parse_cidr`) to centralize IP parsing logic and standardize error messages for validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d24210e4-38db-4e47-bb87-51b37c97f76b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d24210e4-38db-4e47-bb87-51b37c97f76b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

