### PR TITLE
feat: add CI/CD automation workflows

### DIFF
--- a/.github/CONVENTIONAL_COMMITS.md
+++ b/.github/CONVENTIONAL_COMMITS.md
@@ -1,0 +1,338 @@
+# Conventional Commits Quick Reference
+
+This is a quick reference guide for writing conventional commits for the valid8r project.
+
+## Basic Format
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+## Commit Types and Version Bumps
+
+| Type | Bump | Use When | Example |
+|------|------|----------|---------|
+| `feat` | 🔼 **minor** | Adding new feature | `feat: add UUID v7 parsing support` |
+| `fix` | 🔼 **patch** | Fixing a bug | `fix: handle empty strings in parse_int` |
+| `docs` | 🔼 **patch** | Documentation changes | `docs: add examples to README` |
+| `style` | 🔼 **patch** | Code formatting (no logic change) | `style: format with ruff` |
+| `refactor` | 🔼 **patch** | Code refactoring | `refactor: simplify Maybe monad` |
+| `perf` | 🔼 **patch** | Performance improvements | `perf: optimize list parsing` |
+| `test` | 🔼 **patch** | Adding or updating tests | `test: add edge cases for validators` |
+| `chore` | 🔼 **patch** | Maintenance tasks | `chore: update dependencies` |
+| `ci` | ⚪ **none** | CI/CD changes | `ci: add Python 3.13 to matrix` |
+| `build` | ⚪ **none** | Build system changes | `build: update poetry config` |
+
+## Breaking Changes (Major Bump)
+
+### Method 1: Add `!` after type
+
+```bash
+feat!: redesign validation API
+
+Changed validators to return Result instead of Maybe.
+```
+
+### Method 2: Add `BREAKING CHANGE:` footer
+
+```bash
+feat: redesign validation API
+
+BREAKING CHANGE: Validators now return Result[T, E] instead of Maybe[T].
+Update all validator calls to handle the new return type.
+```
+
+## Scopes (Optional)
+
+Scopes indicate which part of the codebase changed:
+
+```
+feat(parsers): add parse_phone_number
+fix(validators): correct float comparison in maximum
+docs(readme): add installation instructions
+test(integration): add API integration tests
+chore(deps): bump pydantic to 2.10
+```
+
+Common scopes for valid8r:
+- `parsers` - Changes to parsing functions
+- `validators` - Changes to validation functions
+- `prompt` - Changes to interactive prompting
+- `core` - Changes to core Maybe monad
+- `testing` - Changes to testing utilities
+- `docs` - Documentation changes
+- `deps` - Dependency updates
+- `ci` - CI/CD workflow changes
+
+## Real Examples
+
+### Feature Addition (Minor Bump)
+
+```bash
+git commit -m "feat(parsers): add parse_ipv6 function
+
+- Validates IPv6 addresses using ipaddress module
+- Returns Success(IPv6Address) or Failure with error
+- Handles compressed and expanded notation"
+```
+
+### Bug Fix (Patch Bump)
+
+```bash
+git commit -m "fix(validators): minimum validator now accepts equal values
+
+Previously minimum(5) would reject the value 5, which was incorrect.
+Now minimum(5) accepts 5 as expected."
+```
+
+### Documentation Update (Patch Bump)
+
+```bash
+git commit -m "docs: add comprehensive guide for custom parsers
+
+Includes:
+- Step-by-step tutorial
+- Best practices
+- Common pitfalls
+- Example implementations"
+```
+
+### Refactoring (Patch Bump)
+
+```bash
+git commit -m "refactor(core): extract error handling into helper functions
+
+No behavior change, improved code organization and testability."
+```
+
+### Performance Improvement (Patch Bump)
+
+```bash
+git commit -m "perf(parsers): use lazy evaluation in parse_list
+
+Reduces memory usage for large lists by 40% and improves
+parsing speed by 25%."
+```
+
+### Test Addition (Patch Bump)
+
+```bash
+git commit -m "test(parsers): add property-based tests for parse_int
+
+Uses hypothesis to test parse_int with randomly generated
+integers and invalid inputs."
+```
+
+### Breaking Change (Major Bump)
+
+```bash
+git commit -m "feat!: replace Maybe with Result monad
+
+BREAKING CHANGE: All parsers now return Result[T, Error] instead
+of Maybe[T].
+
+Migration guide:
+- Replace 'from valid8r.core.maybe import Success, Failure'
+  with 'from valid8r.core.result import Ok, Err'
+- Replace Success(value) with Ok(value)
+- Replace Failure(msg) with Err(Error(msg))
+- Update pattern matching to use Ok/Err
+
+This change provides better error context and aligns with
+Rust-style error handling."
+```
+
+### Dependency Update (Patch Bump)
+
+```bash
+git commit -m "chore(deps): update pydantic from 2.9.0 to 2.10.0
+
+- Fixes security vulnerability CVE-2024-XXXX
+- Improves validation performance
+- No breaking changes"
+```
+
+### CI/CD Update (No Bump)
+
+```bash
+git commit -m "ci: add automatic PyPI publishing workflow
+
+Sets up automatic versioning and publishing to PyPI when
+releases are created."
+```
+
+## Multi-line Commits with Body and Footer
+
+```bash
+git commit -m "feat(parsers): add parse_email with validation options
+
+Added comprehensive email parsing with configurable validation:
+- Domain validation (DNS lookup optional)
+- Length limits (RFC 5321 compliance)
+- Special character handling
+- Unicode support
+
+The parser returns EmailAddress structured type with
+local and domain parts separated.
+
+Closes #123
+Refs #124"
+```
+
+## Tips for Good Commit Messages
+
+1. **Use imperative mood**: "add feature" not "added feature" or "adds feature"
+2. **First line under 72 chars**: Keep subject line concise
+3. **Separate subject from body**: Use blank line between subject and body
+4. **Explain why, not what**: Code shows what changed, commit explains why
+5. **Reference issues**: Use "Closes #123" or "Fixes #456"
+6. **One logical change per commit**: Split unrelated changes into separate commits
+
+## Common Patterns
+
+### Multiple Related Changes
+
+```bash
+feat(parsers): add comprehensive URL parsing
+
+- Add parse_url returning UrlParts struct
+- Add parse_url_simple for basic validation
+- Add support for custom schemes
+- Include query parameter parsing
+```
+
+### Bug Fix with Test
+
+```bash
+fix(validators): handle None values in range validator
+
+Added None check before comparison. Previously would raise
+TypeError when validating None values.
+
+Added regression test to prevent future issues.
+
+Fixes #234
+```
+
+### Documentation with Examples
+
+```bash
+docs(examples): add real-world validation examples
+
+Created examples/ directory with:
+- Form validation example
+- API request validation
+- Configuration file parsing
+- Custom validator creation
+```
+
+## Anti-Patterns (Avoid These)
+
+❌ **Vague messages**:
+```bash
+git commit -m "fix stuff"
+git commit -m "update code"
+git commit -m "changes"
+```
+
+❌ **Missing type**:
+```bash
+git commit -m "add phone parser"  # Should be: feat(parsers): add phone parser
+```
+
+❌ **Wrong type**:
+```bash
+git commit -m "feat: fix bug in validator"  # Should be: fix(validators): ...
+```
+
+❌ **Multiple unrelated changes**:
+```bash
+git commit -m "feat: add parser, fix validator, update docs"
+# Should be 3 separate commits
+```
+
+## Verification Before Commit
+
+Before committing, check:
+
+1. ✅ Type is correct (feat, fix, docs, etc.)
+2. ✅ Scope is appropriate (if used)
+3. ✅ Description is clear and concise
+4. ✅ Breaking changes marked with `!` or `BREAKING CHANGE:`
+5. ✅ Tests pass locally
+6. ✅ Linters pass
+
+```bash
+# Run checks before committing
+poetry run ruff check .
+poetry run mypy valid8r
+poetry run pytest
+
+# Then commit
+git commit -m "feat(parsers): add parse_phone_number"
+```
+
+## GitHub PR Titles
+
+PR titles should also follow conventional commits format, as they become the commit message when squashing:
+
+**Good PR Titles**:
+- `feat(parsers): add UUID validation with version support`
+- `fix(validators): handle edge case in email validation`
+- `docs: improve README with getting started guide`
+
+**Bad PR Titles**:
+- `Add feature` ❌
+- `Bug fix` ❌
+- `Update` ❌
+
+## Automation Details
+
+The `version-and-release.yml` workflow analyzes commits using these rules:
+
+1. **Major bump**: Any commit with `!` or `BREAKING CHANGE:`
+2. **Minor bump**: Any `feat:` commit (if no major bump)
+3. **Patch bump**: Any `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:` commit
+4. **No bump**: Only `ci:` or `build:` commits
+
+The **first matching rule wins**:
+- If any commit is breaking → major bump
+- Else if any commit is feat → minor bump
+- Else if any commit is fix/docs/etc → patch bump
+- Else → no bump
+
+## Questions?
+
+If unsure about commit format:
+
+1. Check this guide
+2. Look at recent commits: `git log --oneline -10`
+3. Review [conventionalcommits.org](https://www.conventionalcommits.org/)
+4. Ask in PR comments or issues
+
+## Quick Decision Tree
+
+```
+Does this change the public API?
+├─ Yes, breaks backward compatibility
+│  └─ Use feat! or fix! with BREAKING CHANGE → Major bump
+└─ No, backward compatible
+   ├─ Adds new feature?
+   │  └─ Use feat: → Minor bump
+   ├─ Fixes bug?
+   │  └─ Use fix: → Patch bump
+   ├─ Updates docs?
+   │  └─ Use docs: → Patch bump
+   ├─ Refactors code?
+   │  └─ Use refactor: → Patch bump
+   ├─ Updates tests?
+   │  └─ Use test: → Patch bump
+   ├─ Maintenance/deps?
+   │  └─ Use chore: → Patch bump
+   └─ Updates CI/CD?
+      └─ Use ci: → No bump
+```

--- a/.github/PYPI_TOKEN_SETUP_GUIDE.md
+++ b/.github/PYPI_TOKEN_SETUP_GUIDE.md
@@ -1,0 +1,297 @@
+# PyPI Token Setup Guide for valid8r
+
+This guide will walk you through setting up PyPI publishing for the valid8r package.
+
+## Step 1: Create PyPI Account (if you don't have one)
+
+1. Go to: https://pypi.org/account/register/
+2. Fill in the registration form:
+   - Username: Choose a username
+   - Email: Your email address
+   - Password: Create a strong password
+3. Verify your email address (check inbox)
+4. **IMPORTANT**: Enable Two-Factor Authentication (2FA)
+   - Go to: https://pypi.org/manage/account/
+   - Click "Account security"
+   - Click "Set up 2FA with an authentication app"
+   - Use an app like Google Authenticator, Authy, or 1Password
+   - Follow the setup wizard
+   - **Save your recovery codes** in a safe place!
+
+> ⚠️ **Note**: 2FA is REQUIRED to create API tokens. You cannot skip this step.
+
+## Step 2: Generate PyPI API Token
+
+1. Go to: https://pypi.org/manage/account/token/
+2. Click **"Add API token"**
+3. Configure the token:
+   - **Token name**: `github-actions-valid8r`
+   - **Scope**: Select **"Entire account"** (for now)
+     - After first successful publish, you can create a project-specific token
+4. Click **"Add token"**
+5. **COPY THE TOKEN IMMEDIATELY** (you'll only see it once!)
+   - Token format: `pypi-AgEIcHlwaS5vcmc...` (starts with `pypi-`)
+   - Store it temporarily in a password manager or secure note
+
+> ⚠️ **IMPORTANT**: You cannot see the token again after closing the page! If you lose it, you'll need to delete and create a new one.
+
+## Step 3: Add Token to GitHub Secrets
+
+### Option A: Using GitHub Web Interface (Recommended)
+
+1. Go to: https://github.com/mikelane/valid8r/settings/secrets/actions
+   - If you don't have access, you need repository admin permissions
+2. Click **"New repository secret"**
+3. Configure the secret:
+   - **Name**: `PYPI_API_TOKEN` (must be exactly this)
+   - **Value**: Paste the token from Step 2 (starts with `pypi-`)
+4. Click **"Add secret"**
+5. Verify the secret appears in the list (value will be hidden)
+
+### Option B: Using GitHub CLI (Alternative)
+
+```bash
+# Make sure you have the token copied to clipboard
+gh secret set PYPI_API_TOKEN --repo mikelane/valid8r
+
+# When prompted, paste the token and press Enter
+```
+
+## Step 4: Configure GitHub Actions Permissions
+
+1. Go to: https://github.com/mikelane/valid8r/settings/actions
+2. Under **"Workflow permissions"**:
+   - Select: ✅ **"Read and write permissions"**
+   - Check: ✅ **"Allow GitHub Actions to create and approve pull requests"**
+3. Click **"Save"**
+
+## Step 5: Verify Configuration
+
+### Check 1: Secrets are configured
+```bash
+gh secret list --repo mikelane/valid8r
+```
+
+Expected output:
+```
+PYPI_API_TOKEN      Updated YYYY-MM-DD
+```
+
+### Check 2: Workflows exist
+```bash
+ls -la .github/workflows/
+```
+
+Expected output:
+```
+ci.yml
+publish-pypi.yml
+version-and-release.yml
+```
+
+### Check 3: Permissions are correct
+- Go to: https://github.com/mikelane/valid8r/settings/actions
+- Confirm "Read and write permissions" is selected
+
+## Step 6: Test the Setup (Optional but Recommended)
+
+### Option A: Test with Test PyPI (Safest)
+
+1. **Create Test PyPI account**: https://test.pypi.org/account/register/
+2. **Generate Test PyPI token**: https://test.pypi.org/manage/account/token/
+3. **Add to GitHub secrets** as `TEST_PYPI_API_TOKEN`
+4. **Manually trigger test publish**:
+   ```bash
+   gh workflow run publish-pypi.yml -f test_pypi=true
+   ```
+5. **Check Test PyPI**: https://test.pypi.org/project/valid8r/
+6. **Test installation**:
+   ```bash
+   pip install --index-url https://test.pypi.org/simple/ \
+               --extra-index-url https://pypi.org/simple/ valid8r
+   ```
+
+### Option B: Create a Test Release (Real PyPI)
+
+1. **Create a small test commit**:
+   ```bash
+   git checkout -b feat/test-release
+   echo "# Testing CI/CD" >> .github/CICD_TEST.md
+   git add .github/CICD_TEST.md
+   git commit -m "feat: test CI/CD pipeline"
+   git push origin feat/test-release
+   ```
+
+2. **Create and merge PR**:
+   ```bash
+   gh pr create --title "feat: test CI/CD pipeline" \
+                --body "Testing the automated release and PyPI publishing workflow"
+   # After CI passes, merge the PR
+   gh pr merge --squash
+   ```
+
+3. **Watch the automation**:
+   - Go to: https://github.com/mikelane/valid8r/actions
+   - Watch the workflows run:
+     1. Version & Release workflow bumps version
+     2. Publish to PyPI workflow builds and publishes
+   - Check the release: https://github.com/mikelane/valid8r/releases
+   - Check PyPI: https://pypi.org/project/valid8r/
+
+4. **Test installation**:
+   ```bash
+   pip install valid8r
+   python -c "from valid8r.core.parsers import parse_int; print(parse_int('42'))"
+   ```
+
+## Troubleshooting
+
+### Issue: "Secret PYPI_API_TOKEN is not set"
+
+**Solution**:
+- Verify the secret name is EXACTLY `PYPI_API_TOKEN` (case-sensitive)
+- Check you added it to the correct repository
+- Verify you have admin access to the repository
+
+### Issue: "Invalid credentials" when publishing
+
+**Solution**:
+- Token might be expired or invalid
+- Regenerate token on PyPI: https://pypi.org/manage/account/token/
+- Delete old secret and add new one to GitHub
+
+### Issue: "2FA required" error
+
+**Solution**:
+- Enable 2FA on your PyPI account: https://pypi.org/manage/account/
+- You MUST have 2FA enabled to create API tokens
+
+### Issue: "Package name already taken"
+
+**Solution**:
+- Check if `valid8r` is already registered on PyPI
+- If it's your package, you need to add your PyPI username as a maintainer
+- If it's someone else's package, you need to choose a different name in `pyproject.toml`
+
+### Issue: "Version already exists" (expected behavior)
+
+This is **normal** and **expected**! The workflow will skip publishing if the version already exists.
+
+**To publish a new version**:
+1. Make changes and commit with conventional commit format
+2. The version will auto-bump based on your commit
+3. New version will be published automatically
+
+### Issue: Workflow runs but doesn't publish
+
+**Check**:
+1. Does the version in `pyproject.toml` already exist on PyPI?
+   ```bash
+   pip index versions valid8r
+   ```
+2. Did the version actually bump?
+   ```bash
+   git log --oneline -5
+   git tag -l
+   ```
+3. Check the workflow logs for error messages
+
+## Security Best Practices
+
+### Token Security
+- ✅ Never commit tokens to git
+- ✅ Never share tokens in chat/email
+- ✅ Store tokens only in GitHub Secrets
+- ✅ Use project-scoped tokens when possible
+- ✅ Rotate tokens every 6-12 months
+
+### Account Security
+- ✅ Enable 2FA on PyPI account
+- ✅ Use a strong, unique password
+- ✅ Save recovery codes in a password manager
+- ✅ Review account activity regularly
+
+### Token Permissions
+- 🔶 Initially use "Entire account" scope
+- ✅ After first publish, create project-specific token:
+  1. Go to: https://pypi.org/manage/project/valid8r/settings/
+  2. Create new token with scope: "Project: valid8r"
+  3. Update GitHub secret with new token
+  4. Delete the "Entire account" token
+
+## Monitoring
+
+### Check Recent Publishes
+```bash
+# View PyPI package page
+open https://pypi.org/project/valid8r/
+
+# Check installed version
+pip show valid8r
+
+# View all versions
+pip index versions valid8r
+```
+
+### Monitor Workflow Runs
+```bash
+# List recent workflow runs
+gh run list --workflow=publish-pypi.yml --limit 5
+
+# View specific run
+gh run view <run-id>
+
+# Watch live
+gh run watch
+```
+
+### Check Download Stats
+- PyPI Stats: https://pypistats.org/packages/valid8r
+- Downloads badge: ![PyPI Downloads](https://img.shields.io/pypi/dm/valid8r)
+
+## Next Steps
+
+Once setup is complete:
+
+1. ✅ Token configured in GitHub secrets
+2. ✅ Permissions enabled for GitHub Actions
+3. ✅ Test release created (optional)
+4. ✅ Package published to PyPI
+
+You're ready to use the automated workflow! 🎉
+
+### Normal Developer Workflow
+
+From now on, publishing is automatic:
+
+```bash
+# Make changes
+git checkout -b feat/new-feature
+# ... edit code ...
+
+# Commit with conventional format
+git commit -m "feat: add amazing feature"
+
+# Create PR
+gh pr create --title "feat: add amazing feature"
+
+# After review and merge to main:
+# - Version auto-bumps (0.1.0 → 0.2.0)
+# - Release created on GitHub
+# - Package published to PyPI
+# - pip install valid8r gets the new version!
+```
+
+## Support
+
+If you need help:
+- Review `.github/WORKFLOWS.md` for detailed workflow documentation
+- Check `.github/TROUBLESHOOTING.md` for common issues
+- Review GitHub Actions logs for error messages
+- Check PyPI account for token status
+
+---
+
+**Status**: Setup guide created on 2025-10-21
+**Maintainer**: Mike Lane
+**Repository**: https://github.com/mikelane/valid8r

--- a/.github/QUICK_REFERENCE.md
+++ b/.github/QUICK_REFERENCE.md
@@ -1,0 +1,119 @@
+# Quick Reference - valid8r CI/CD
+
+## Commit Message Format
+
+```
+<type>[optional scope]: <description>
+```
+
+### Version Bumps
+
+| Type | Version Change | Example |
+|------|----------------|---------|
+| `feat:` | 0.1.0 → **0.2.0** | `feat: add UUID parser` |
+| `fix:` | 0.1.0 → **0.1.1** | `fix: handle None values` |
+| `docs:` | 0.1.0 → **0.1.1** | `docs: update README` |
+| `feat!:` | 0.1.0 → **1.0.0** | `feat!: redesign API` |
+| `ci:` | **no change** | `ci: update workflow` |
+
+## Common Commands
+
+### Development
+
+```bash
+# Create feature branch
+git checkout -b feat/my-feature
+
+# Commit with conventional format
+git commit -m "feat(parsers): add phone validation"
+
+# Create PR
+gh pr create --fill
+
+# Run checks locally
+poetry run pytest
+poetry run mypy valid8r
+poetry run ruff check .
+```
+
+### Manual Workflow Triggers
+
+```bash
+# Manual version bump
+gh workflow run version-and-release.yml -f version_bump=minor
+
+# Test PyPI publish
+gh workflow run publish-pypi.yml -f test_pypi=true
+
+# Manual CI run
+gh workflow run ci.yml
+```
+
+### Check Status
+
+```bash
+# View workflow runs
+gh run list
+
+# View latest release
+gh release view
+
+# Check PyPI version
+pip index versions valid8r
+```
+
+## Workflow Sequence
+
+1. **Create PR** → CI runs (tests, linting, type checking)
+2. **Merge to main** → Version bump + GitHub Release
+3. **Release created** → Publish to PyPI
+4. **Published** → Available via `pip install valid8r`
+
+## Secrets Required
+
+- `PYPI_API_TOKEN` - Required for PyPI publishing
+- `TEST_PYPI_API_TOKEN` - Optional for testing
+- `CODECOV_TOKEN` - Optional for coverage
+
+## Documentation
+
+- **[WORKFLOWS.md](WORKFLOWS.md)** - Complete workflows guide
+- **[CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md)** - Commit format reference
+- **[SETUP_CHECKLIST.md](SETUP_CHECKLIST.md)** - Repository setup steps
+- **[README.md](README.md)** - GitHub config overview
+
+## Links
+
+- Workflows: https://github.com/mikelane/valid8r/actions
+- Releases: https://github.com/mikelane/valid8r/releases
+- PyPI: https://pypi.org/project/valid8r/
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Version not bumping | Check commits follow `feat:`, `fix:` format |
+| PyPI publish fails | Verify `PYPI_API_TOKEN` secret is set |
+| CI checks failing | Run locally: `poetry run pytest && poetry run ruff check .` |
+| Permission denied | Enable write permissions in Actions settings |
+
+## Example Commits
+
+```bash
+# Feature (minor)
+git commit -m "feat(parsers): add email validation"
+
+# Bug fix (patch)
+git commit -m "fix(validators): correct regex pattern"
+
+# Breaking change (major)
+git commit -m "feat!: replace Maybe with Result
+
+BREAKING CHANGE: All parsers return Result instead of Maybe"
+
+# Documentation (patch)
+git commit -m "docs: add examples to tutorial"
+
+# No version change
+git commit -m "ci: add Python 3.14 to matrix"
+```

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,368 @@
+# GitHub Configuration for valid8r
+
+This directory contains all GitHub-specific configuration for the valid8r project, including CI/CD workflows, issue templates, and documentation.
+
+## Quick Links
+
+- **[Workflows Documentation](WORKFLOWS.md)** - Complete guide to CI/CD workflows
+- **[Setup Checklist](SETUP_CHECKLIST.md)** - Step-by-step repository setup guide
+- **[Conventional Commits Guide](CONVENTIONAL_COMMITS.md)** - Quick reference for commit messages
+
+## Directory Structure
+
+```
+.github/
+├── workflows/
+│   ├── ci.yml                      # Continuous Integration (tests, linting, type checking)
+│   ├── version-and-release.yml     # Automatic versioning and GitHub releases
+│   └── publish-pypi.yml            # PyPI package publishing
+├── ISSUE_TEMPLATE/
+│   └── ... (issue templates)
+├── CODEOWNERS                       # Code ownership and review assignments
+├── dependabot.yml                   # Dependency update automation
+├── pull_request_template.md         # PR template for contributors
+├── WORKFLOWS.md                     # Complete workflows documentation
+├── CONVENTIONAL_COMMITS.md          # Commit message format guide
+├── SETUP_CHECKLIST.md              # Initial repository setup steps
+└── README.md                        # This file
+```
+
+## Workflows Overview
+
+### 1. CI Workflow (`workflows/ci.yml`)
+
+**Runs on**: Every pull request and push to main
+
+**Purpose**: Ensure code quality and prevent bugs from reaching production
+
+**Checks**:
+- Linting with ruff (code quality and formatting)
+- Type checking with mypy
+- Unit tests on Python 3.11, 3.12, 3.13
+- BDD tests with behave
+- Documentation build
+- Smoke tests
+- Coverage reporting
+
+**Status**: ✅ All checks must pass before merging
+
+### 2. Version and Release Workflow (`workflows/version-and-release.yml`)
+
+**Runs on**: Pushes to main branch
+
+**Purpose**: Automate semantic versioning based on conventional commits
+
+**Process**:
+1. Analyzes commit messages since last release
+2. Determines version bump (major, minor, or patch)
+3. Updates `pyproject.toml` version
+4. Creates git tag (e.g., `v0.2.0`)
+5. Generates changelog from commits
+6. Creates GitHub Release with notes
+
+**Versioning Rules**:
+- `feat:` commits → Minor version bump (0.1.0 → 0.2.0)
+- `fix:`, `docs:`, etc. → Patch version bump (0.1.0 → 0.1.1)
+- `BREAKING CHANGE:` or `feat!:` → Major version bump (0.1.0 → 1.0.0)
+
+### 3. Publish to PyPI Workflow (`workflows/publish-pypi.yml`)
+
+**Runs on**: GitHub release published (triggered by version-and-release workflow)
+
+**Purpose**: Automatically publish package to PyPI
+
+**Process**:
+1. Checks if version already exists on PyPI (prevents duplicates)
+2. Builds wheel and source distribution
+3. Tests built package on all Python versions
+4. Publishes to PyPI using API token
+5. Verifies publication
+
+**Safety**: Skips publishing if version already exists
+
+## For Contributors
+
+### Writing Commit Messages
+
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+```
+
+**Common types**:
+- `feat:` - New feature (minor version bump)
+- `fix:` - Bug fix (patch version bump)
+- `docs:` - Documentation changes (patch version bump)
+- `refactor:` - Code refactoring (patch version bump)
+- `test:` - Test updates (patch version bump)
+- `chore:` - Maintenance tasks (patch version bump)
+
+**Examples**:
+```bash
+git commit -m "feat(parsers): add UUID parsing support"
+git commit -m "fix(validators): handle None in minimum validator"
+git commit -m "docs: add examples to README"
+```
+
+See [CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md) for detailed guide.
+
+### Creating Pull Requests
+
+1. Create feature branch: `git checkout -b feat/my-feature`
+2. Make changes and commit with conventional format
+3. Push and create PR
+4. Ensure all CI checks pass
+5. Wait for review and approval
+6. Squash and merge (PR title becomes commit message)
+
+PR title should also follow conventional commits format:
+```
+feat(parsers): add phone number validation
+fix(validators): correct email regex pattern
+docs: improve getting started guide
+```
+
+### Development Workflow
+
+```bash
+# 1. Create feature branch
+git checkout -b feat/add-parser
+
+# 2. Make changes
+# ... edit code ...
+
+# 3. Run tests locally
+poetry run pytest
+poetry run mypy valid8r
+poetry run ruff check .
+
+# 4. Commit with conventional format
+git commit -m "feat(parsers): add phone number parser"
+
+# 5. Push and create PR
+git push origin feat/add-parser
+gh pr create --fill
+
+# 6. Wait for CI checks to pass
+# 7. Get review approval
+# 8. Merge to main
+
+# 9. Automatic version bump happens on main
+# 10. Automatic PyPI publish happens after release
+```
+
+## For Repository Administrators
+
+### Initial Setup
+
+Follow the [SETUP_CHECKLIST.md](SETUP_CHECKLIST.md) for complete setup instructions.
+
+**Key steps**:
+1. Create PyPI account and generate API token
+2. Add `PYPI_API_TOKEN` to GitHub secrets
+3. Configure branch protection rules
+4. Enable GitHub Actions with write permissions
+5. Test workflows with a test release
+
+### Secrets Required
+
+**Required**:
+- `PYPI_API_TOKEN` - PyPI API token for publishing
+
+**Optional**:
+- `TEST_PYPI_API_TOKEN` - Test PyPI token for testing
+- `CODECOV_TOKEN` - Codecov token for coverage reporting
+
+### Branch Protection
+
+The `main` branch should be protected with these rules:
+- Require pull request reviews (1+ approvals)
+- Require status checks to pass:
+  - Lint and Format Check
+  - Type Check (mypy)
+  - Test (Python 3.11, 3.12, 3.13)
+  - BDD Tests
+  - All Checks Passed
+- Require conversation resolution
+- Require linear history
+- Prevent force pushes
+- Prevent deletions
+
+### Manual Triggers
+
+All workflows can be manually triggered:
+
+```bash
+# Manual version bump (override automatic detection)
+gh workflow run version-and-release.yml -f version_bump=minor
+
+# Manual PyPI publish
+gh workflow run publish-pypi.yml
+
+# Publish to Test PyPI
+gh workflow run publish-pypi.yml -f test_pypi=true
+```
+
+## Troubleshooting
+
+### Workflows Not Running
+
+**Check**:
+1. GitHub Actions enabled: `Settings` → `Actions` → `General`
+2. Workflow files in correct location: `.github/workflows/`
+3. Valid YAML syntax: Use `yamllint` or GitHub's editor
+
+### Version Not Bumping
+
+**Check**:
+1. Commits follow conventional format
+2. Commits since last tag use proper types (`feat:`, `fix:`, etc.)
+3. Not only `ci:` or `build:` commits (these don't trigger bumps)
+
+### PyPI Publishing Failed
+
+**Check**:
+1. `PYPI_API_TOKEN` secret is set correctly
+2. PyPI account has 2FA enabled
+3. Package name not already taken
+4. Version not already published
+5. Token has correct scope (account or project)
+
+### CI Checks Failing
+
+**Run locally**:
+```bash
+poetry run ruff check .
+poetry run ruff format --check .
+poetry run mypy valid8r
+poetry run pytest
+poetry run behave tests/bdd/features
+```
+
+Fix issues and push again.
+
+## Documentation
+
+### Complete Documentation
+
+- **[WORKFLOWS.md](WORKFLOWS.md)**: Comprehensive guide to all workflows, including:
+  - Detailed workflow descriptions
+  - Trigger conditions
+  - Job breakdowns
+  - Conventional commits specification
+  - Developer workflow guide
+  - Troubleshooting guide
+
+- **[CONVENTIONAL_COMMITS.md](CONVENTIONAL_COMMITS.md)**: Quick reference for commit message format:
+  - Commit types and version bumps
+  - Examples for every scenario
+  - Breaking change formats
+  - Anti-patterns to avoid
+  - Decision tree for choosing commit type
+
+- **[SETUP_CHECKLIST.md](SETUP_CHECKLIST.md)**: Step-by-step setup guide:
+  - PyPI account creation
+  - API token generation
+  - GitHub secrets configuration
+  - Branch protection setup
+  - Initial testing procedures
+  - Troubleshooting common issues
+
+### Additional Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [Poetry Publishing Guide](https://python-poetry.org/docs/libraries/#publishing-to-pypi)
+
+## Workflow Automation Summary
+
+```
+Developer Workflow:
+┌─────────────────┐
+│ Create PR       │
+│ (feat: ...)     │
+└────────┬────────┘
+         │
+         ▼
+    ┌────────┐
+    │   CI   │ ◄── Lint, Type Check, Test, BDD
+    └────┬───┘
+         │
+         ▼
+    ┌─────────┐
+    │ Merge   │
+    │ to main │
+    └────┬────┘
+         │
+         ▼
+┌──────────────────┐
+│ Version Bump     │ ◄── Auto-detect from commits
+│ & Release        │     Update version, create tag & release
+└────────┬─────────┘
+         │
+         ▼
+┌──────────────────┐
+│ Publish to PyPI  │ ◄── Build, test, publish
+└──────────────────┘
+         │
+         ▼
+    ┌────────┐
+    │ Done!  │ Package available: pip install valid8r
+    └────────┘
+```
+
+## Monitoring and Maintenance
+
+### Regular Checks
+
+- Review GitHub Actions logs for failed workflows
+- Monitor PyPI releases: https://pypi.org/project/valid8r/
+- Check coverage trends on Codecov
+- Update Python versions in test matrix annually
+- Rotate API tokens every 6 months
+
+### Version History
+
+View all releases: https://github.com/mikelane/valid8r/releases
+
+### CI/CD Status
+
+Check current status: https://github.com/mikelane/valid8r/actions
+
+## Support
+
+**Issues with workflows?**
+1. Check workflow logs in Actions tab
+2. Review documentation in this directory
+3. Open an issue with workflow name and error details
+
+**Questions about setup?**
+1. Follow [SETUP_CHECKLIST.md](SETUP_CHECKLIST.md)
+2. Check troubleshooting sections
+3. Review GitHub Actions documentation
+
+## Contributing to Workflows
+
+When updating workflows:
+
+1. Test changes in a fork first
+2. Use manual trigger to test (`workflow_dispatch`)
+3. Document changes in commit message
+4. Update documentation files as needed
+5. Use `ci: update workflow...` commit type (won't trigger version bump)
+
+Example:
+```bash
+git commit -m "ci: add Python 3.14 to test matrix
+
+Updates CI workflow to test against Python 3.14 beta.
+No changes to versioning or publishing logic."
+```
+
+## License
+
+These workflow configurations are part of the valid8r project and follow the same MIT license.

--- a/.github/SETUP_CHECKLIST.md
+++ b/.github/SETUP_CHECKLIST.md
@@ -1,0 +1,318 @@
+# GitHub Repository Setup Checklist
+
+This checklist ensures the valid8r repository is properly configured for the CI/CD workflows.
+
+## Pre-Deployment Checklist
+
+### 1. PyPI Account Setup
+
+- [ ] Create PyPI account at https://pypi.org/account/register/
+- [ ] Verify email address
+- [ ] Enable 2FA (required for API tokens)
+- [ ] (Optional) Create Test PyPI account at https://test.pypi.org/account/register/
+
+### 2. PyPI API Tokens
+
+#### Production PyPI Token
+
+- [ ] Go to https://pypi.org/manage/account/token/
+- [ ] Click "Add API token"
+  - Token name: `github-actions-valid8r`
+  - Scope: "Entire account" (change to project scope after first publish)
+- [ ] Copy token (starts with `pypi-`, save securely)
+- [ ] Store token in password manager
+
+#### Test PyPI Token (Optional)
+
+- [ ] Go to https://test.pypi.org/manage/account/token/
+- [ ] Click "Add API token"
+  - Token name: `github-actions-valid8r-test`
+  - Scope: "Entire account"
+- [ ] Copy token
+- [ ] Store token in password manager
+
+### 3. GitHub Repository Secrets
+
+- [ ] Go to repository `Settings` → `Secrets and variables` → `Actions`
+- [ ] Click "New repository secret"
+
+**Required Secret**:
+- [ ] Name: `PYPI_API_TOKEN`
+  - Value: `pypi-...` (paste the production PyPI token)
+
+**Optional Secrets**:
+- [ ] Name: `TEST_PYPI_API_TOKEN`
+  - Value: `pypi-...` (paste the test PyPI token)
+- [ ] Name: `CODECOV_TOKEN`
+  - Get from https://codecov.io/ after linking repository
+  - Used for coverage reporting
+
+### 4. GitHub Repository Settings
+
+#### General Settings
+
+- [ ] Go to `Settings` → `General`
+- [ ] Ensure "Allow merge commits" is enabled (or squash/rebase as preferred)
+- [ ] Consider enabling "Automatically delete head branches"
+
+#### Actions Permissions
+
+- [ ] Go to `Settings` → `Actions` → `General`
+- [ ] Workflow permissions:
+  - [ ] Select "Read and write permissions"
+  - [ ] ✅ Check "Allow GitHub Actions to create and approve pull requests"
+
+#### Branch Protection Rules
+
+- [ ] Go to `Settings` → `Branches` → `Add rule`
+- [ ] Branch name pattern: `main`
+
+**Protection Settings**:
+- [ ] ✅ Require pull request before merging
+  - [ ] Required approvals: 1 (or more)
+  - [ ] ✅ Dismiss stale pull request approvals when new commits are pushed
+  - [ ] (Optional) ✅ Require review from Code Owners
+- [ ] ✅ Require status checks to pass before merging
+  - [ ] ✅ Require branches to be up to date before merging
+  - [ ] Select required checks:
+    - [ ] `Lint and Format Check`
+    - [ ] `Type Check (mypy)`
+    - [ ] `Test (Python 3.11)`
+    - [ ] `Test (Python 3.12)`
+    - [ ] `Test (Python 3.13)`
+    - [ ] `BDD Tests`
+    - [ ] `Build Documentation`
+    - [ ] `Smoke Test`
+    - [ ] `All Checks Passed`
+- [ ] ✅ Require conversation resolution before merging
+- [ ] (Optional) ✅ Require signed commits
+- [ ] ✅ Require linear history
+- [ ] ✅ Include administrators (enforce rules for admins too)
+- [ ] ❌ DO NOT enable "Allow force pushes"
+- [ ] ❌ DO NOT enable "Allow deletions"
+
+#### Environments (for controlled PyPI publishing)
+
+Create `pypi` environment:
+- [ ] Go to `Settings` → `Environments` → `New environment`
+- [ ] Name: `pypi`
+- [ ] (Optional) Required reviewers: Add team members who should approve releases
+- [ ] Environment secrets:
+  - [ ] Add `PYPI_API_TOKEN` (same value as repository secret)
+
+Create `test-pypi` environment (optional):
+- [ ] Name: `test-pypi`
+- [ ] Environment secrets:
+  - [ ] Add `TEST_PYPI_API_TOKEN`
+
+### 5. Codecov Integration (Optional)
+
+- [ ] Go to https://codecov.io/
+- [ ] Sign in with GitHub
+- [ ] Add `mikelane/valid8r` repository
+- [ ] Copy upload token
+- [ ] Add `CODECOV_TOKEN` to GitHub secrets (see step 3)
+
+### 6. Initial PyPI Registration
+
+**Important**: PyPI requires the package name to be registered before the first publish.
+
+**Option A: Manual First Publish** (Recommended)
+
+```bash
+# Ensure version is 0.1.0 in pyproject.toml
+poetry version 0.1.0
+
+# Build the package
+poetry build
+
+# Publish to Test PyPI first (to verify)
+poetry config repositories.testpypi https://test.pypi.org/legacy/
+poetry publish -r testpypi --username __token__ --password pypi-...
+
+# If test publish succeeds, publish to production PyPI
+poetry publish --username __token__ --password pypi-...
+```
+
+**Option B: Trusted Publisher** (More secure, no tokens needed)
+
+- [ ] Go to https://pypi.org/manage/account/publishing/
+- [ ] Click "Add a new pending publisher"
+  - PyPI Project Name: `valid8r`
+  - Owner: `mikelane`
+  - Repository name: `valid8r`
+  - Workflow filename: `publish-pypi.yml`
+  - Environment name: `pypi`
+- [ ] After setup, remove `password:` from workflow and it will use OIDC
+
+### 7. Test Workflows
+
+After setup is complete, test each workflow:
+
+#### Test CI Workflow
+
+- [ ] Create a test branch: `git checkout -b test/ci-workflow`
+- [ ] Make a small change (e.g., update README)
+- [ ] Push and create PR
+- [ ] Verify all CI checks pass in PR
+- [ ] Close PR without merging
+
+#### Test Version Bump Workflow
+
+- [ ] Create a feature branch: `git checkout -b feat/test-versioning`
+- [ ] Make a small change
+- [ ] Commit with conventional format: `git commit -m "feat: test versioning workflow"`
+- [ ] Create PR and merge to main
+- [ ] Check Actions tab for "Version and Release" workflow
+- [ ] Verify:
+  - [ ] Version bumped in pyproject.toml
+  - [ ] Git tag created (e.g., v0.2.0)
+  - [ ] GitHub Release created with changelog
+- [ ] Check releases: https://github.com/mikelane/valid8r/releases
+
+#### Test PyPI Publishing Workflow
+
+After version bump creates a release:
+
+- [ ] Go to Actions tab
+- [ ] Check "Publish to PyPI" workflow
+- [ ] Verify:
+  - [ ] Package built successfully
+  - [ ] Tests passed on built package
+  - [ ] Published to PyPI (if configured)
+- [ ] Test installation: `pip install valid8r`
+- [ ] Check PyPI page: https://pypi.org/project/valid8r/
+
+### 8. Verify Complete Setup
+
+Final verification checklist:
+
+- [ ] All GitHub secrets are configured
+- [ ] Branch protection rules are active
+- [ ] CI workflow runs on PRs
+- [ ] Version workflow runs on main branch pushes
+- [ ] PyPI workflow runs on releases
+- [ ] Can install package from PyPI: `pip install valid8r`
+- [ ] Documentation is up to date
+
+## Troubleshooting Common Issues
+
+### Issue: "Permission denied" when workflow tries to push
+
+**Solution**:
+- Go to `Settings` → `Actions` → `General`
+- Set "Workflow permissions" to "Read and write permissions"
+- Enable "Allow GitHub Actions to create and approve pull requests"
+
+### Issue: "PyPI upload failed: 403 Forbidden"
+
+**Possible causes**:
+1. Invalid API token
+   - Solution: Regenerate token and update secret
+2. Package name already taken
+   - Solution: Change package name in pyproject.toml
+3. 2FA not enabled on PyPI account
+   - Solution: Enable 2FA in PyPI account settings
+
+### Issue: "Version already exists on PyPI"
+
+**Expected behavior**: The workflow skips publishing if version exists.
+
+**If you need to republish**:
+1. Bump version manually: `poetry version patch`
+2. Commit and push to trigger new release
+
+### Issue: Required checks not appearing in branch protection
+
+**Solution**:
+1. The checks must run at least once before they appear in the list
+2. Create a test PR to trigger all workflows
+3. After workflows complete, the checks will be available in settings
+
+### Issue: Workflow not triggering
+
+**Check**:
+1. Workflow file has correct `on:` triggers
+2. Branch protection isn't blocking pushes
+3. Actions are enabled: `Settings` → `Actions` → `General` → "Allow all actions"
+
+## Post-Setup Maintenance
+
+### After First Successful Publish
+
+- [ ] Update PyPI API token scope from "Entire account" to "Project: valid8r"
+- [ ] Go to https://pypi.org/manage/account/token/
+- [ ] Delete old token
+- [ ] Create new token with project scope
+- [ ] Update `PYPI_API_TOKEN` secret in GitHub
+
+### Regular Maintenance
+
+- [ ] Review and rotate API tokens every 6 months
+- [ ] Check for workflow updates in GitHub Actions marketplace
+- [ ] Update Python versions in test matrix as new versions release
+- [ ] Review branch protection rules periodically
+
+### Documentation Updates
+
+- [ ] Update README with installation instructions after first PyPI publish
+- [ ] Add badge for PyPI version
+- [ ] Add badge for CI status
+- [ ] Add badge for coverage (if using Codecov)
+
+Example badges for README.md:
+
+```markdown
+[![PyPI version](https://badge.fury.io/py/valid8r.svg)](https://badge.fury.io/py/valid8r)
+[![CI](https://github.com/mikelane/valid8r/actions/workflows/ci.yml/badge.svg)](https://github.com/mikelane/valid8r/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/mikelane/valid8r/branch/main/graph/badge.svg)](https://codecov.io/gh/mikelane/valid8r)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+```
+
+## Security Considerations
+
+### Secrets Management
+
+- [ ] Never commit secrets to repository
+- [ ] Use GitHub encrypted secrets for all tokens
+- [ ] Rotate tokens regularly
+- [ ] Use environment-specific secrets for production vs test
+
+### Branch Protection
+
+- [ ] Prevent force pushes to main
+- [ ] Require PR reviews
+- [ ] Require status checks
+- [ ] Protect against accidental deletions
+
+### PyPI Security
+
+- [ ] Enable 2FA on PyPI account
+- [ ] Use scoped tokens (project-specific, not account-wide)
+- [ ] Consider trusted publishers (OIDC) instead of API tokens
+- [ ] Monitor PyPI package for unauthorized changes
+
+## Support
+
+If you encounter issues during setup:
+
+1. Review this checklist
+2. Check GitHub Actions logs
+3. Review `.github/WORKFLOWS.md` documentation
+4. Open an issue with details
+
+## Checklist Complete!
+
+Once all items are checked:
+
+- [ ] Repository is fully configured
+- [ ] CI/CD workflows are operational
+- [ ] PyPI publishing is automated
+- [ ] Team members are informed of conventional commit requirements
+- [ ] Documentation is accessible
+
+**Next Steps**:
+- Share `.github/CONVENTIONAL_COMMITS.md` with team
+- Add contributing guidelines to README
+- Start using conventional commits for all changes
+- Monitor first few releases to ensure smooth operation

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -1,0 +1,488 @@
+# GitHub Actions Workflows Documentation
+
+This document describes the GitHub Actions CI/CD workflows configured for the valid8r package.
+
+## Workflows Overview
+
+### 1. CI Workflow (`ci.yml`)
+
+**Triggers**:
+- Pull requests to `main`
+- Pushes to `main`
+- Manual dispatch
+
+**Jobs**:
+- **Lint**: Runs ruff (check + format) and isort
+- **Type Check**: Runs mypy type checking
+- **Test**: Runs unit tests on Python 3.11, 3.12, 3.13 with coverage
+- **BDD Test**: Runs behave BDD tests
+- **Docs**: Builds Sphinx documentation
+- **Smoke Test**: Runs smoke_test.py
+- **All Checks**: Gate job that ensures all checks pass
+
+**Purpose**: Ensures code quality on every PR and push to main.
+
+### 2. Version and Release Workflow (`version-and-release.yml`)
+
+**Triggers**:
+- Pushes to `main` (automatic version bump based on conventional commits)
+- Manual dispatch (with optional manual version bump override)
+
+**Jobs**:
+- Analyzes commit messages using conventional commits format
+- Determines version bump type (major, minor, patch)
+- Updates version in `pyproject.toml` using Poetry
+- Creates git tag (e.g., `v0.2.0`)
+- Generates categorized changelog from commits
+- Creates GitHub Release with release notes
+
+**Version Bump Rules**:
+- **Major** (1.0.0 → 2.0.0):
+  - Commits with `BREAKING CHANGE:` in body
+  - Commits with `!` after type: `feat!:`, `fix!:`
+- **Minor** (0.1.0 → 0.2.0):
+  - Commits starting with `feat:`
+- **Patch** (0.1.0 → 0.1.1):
+  - Commits starting with `fix:`, `chore:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`
+- **No bump**: Commits without conventional format
+
+### 3. Publish to PyPI Workflow (`publish-pypi.yml`)
+
+**Triggers**:
+- GitHub Release published (automatic after version-and-release.yml)
+- Manual dispatch (with option to publish to Test PyPI)
+
+**Jobs**:
+- **Check Version**: Verifies version doesn't already exist on PyPI
+- **Build**: Creates wheel and source distribution using Poetry
+- **Test Built Package**: Installs and smoke tests the wheel on Python 3.11, 3.12, 3.13
+- **Publish to PyPI**: Publishes to PyPI (if not already published)
+- **Publish to Test PyPI**: Alternative publish target (manual only)
+- **Notify**: Confirmation message
+
+**Safety Features**:
+- Skips publishing if version already exists on PyPI
+- Tests built package before publishing
+- Uses trusted publisher (OIDC) or API token authentication
+- `skip-existing` prevents duplicate uploads
+
+## Setup Instructions
+
+### Required GitHub Secrets
+
+Configure these secrets in your repository settings (`Settings` → `Secrets and variables` → `Actions`):
+
+#### For PyPI Publishing (Required)
+
+**Option 1: API Token (Recommended for initial setup)**
+
+1. Go to [PyPI Account Settings](https://pypi.org/manage/account/)
+2. Scroll to "API tokens" and click "Add API token"
+3. Name: `github-actions-valid8r`
+4. Scope: "Entire account" (or specific to `valid8r` project once it exists)
+5. Copy the token (starts with `pypi-`)
+6. In GitHub: `Settings` → `Secrets` → `New repository secret`
+   - Name: `PYPI_API_TOKEN`
+   - Value: `pypi-...` (paste the token)
+
+**Option 2: Trusted Publisher (Recommended for production)**
+
+1. Go to [PyPI Publishing Settings](https://pypi.org/manage/account/publishing/)
+2. Add a new pending publisher:
+   - PyPI Project Name: `valid8r`
+   - Owner: `mikelane` (your GitHub username/org)
+   - Repository: `valid8r`
+   - Workflow name: `publish-pypi.yml`
+   - Environment name: `pypi`
+3. Once configured, remove `password:` line from workflow and add `permissions: id-token: write`
+
+#### For Test PyPI (Optional)
+
+1. Go to [Test PyPI Account Settings](https://test.pypi.org/manage/account/)
+2. Create API token same as above
+3. In GitHub: Add secret `TEST_PYPI_API_TOKEN`
+
+#### For Codecov (Optional)
+
+1. Go to [Codecov](https://codecov.io/) and link your repository
+2. Copy the upload token
+3. In GitHub: Add secret `CODECOV_TOKEN`
+
+### Repository Settings
+
+Configure GitHub repository settings:
+
+1. **Branch Protection for `main`**:
+   - `Settings` → `Branches` → `Add rule` for `main`
+   - ✅ Require pull request before merging
+   - ✅ Require status checks to pass before merging
+     - Select: `Lint and Format Check`, `Type Check (mypy)`, `Test (Python 3.11)`, `BDD Tests`, `All Checks Passed`
+   - ✅ Require conversation resolution before merging
+   - ✅ Do not allow bypassing the above settings
+
+2. **Actions Permissions**:
+   - `Settings` → `Actions` → `General`
+   - Workflow permissions: "Read and write permissions"
+   - ✅ Allow GitHub Actions to create and approve pull requests
+
+3. **Environments** (for PyPI publishing):
+   - `Settings` → `Environments` → `New environment`
+   - Name: `pypi`
+   - (Optional) Add required reviewers for production deployments
+   - Add environment secret: `PYPI_API_TOKEN`
+
+## Usage Guide for Developers
+
+### Conventional Commits Format
+
+All commits should follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+#### Commit Types
+
+| Type | Version Bump | Description | Example |
+|------|-------------|-------------|---------|
+| `feat` | **minor** | New feature | `feat: add parse_uuid function` |
+| `fix` | **patch** | Bug fix | `fix: handle empty string in parse_int` |
+| `docs` | **patch** | Documentation only | `docs: update README with examples` |
+| `style` | **patch** | Formatting, no code change | `style: fix indentation in parsers.py` |
+| `refactor` | **patch** | Code refactoring | `refactor: simplify Maybe.bind implementation` |
+| `perf` | **patch** | Performance improvement | `perf: optimize parse_list for large inputs` |
+| `test` | **patch** | Add/update tests | `test: add edge cases for parse_email` |
+| `chore` | **patch** | Build/tooling changes | `chore: update dependencies` |
+| `ci` | **none** | CI/CD changes | `ci: add Python 3.13 to test matrix` |
+
+#### Breaking Changes (Major Version Bump)
+
+**Option 1: `!` after type**:
+```
+feat!: change parse_int to return Result instead of Maybe
+
+This is a breaking change that affects all users of parse_int.
+```
+
+**Option 2: `BREAKING CHANGE:` in footer**:
+```
+feat: redesign validation API
+
+BREAKING CHANGE: validators now return Maybe[T] instead of bool
+```
+
+### Example Commit Messages
+
+**Feature (minor bump)**:
+```bash
+git commit -m "feat(parsers): add parse_phone_number with international support
+
+- Supports E.164 format
+- Returns PhoneNumber structured type
+- Includes country code validation"
+```
+
+**Bug Fix (patch bump)**:
+```bash
+git commit -m "fix(validators): maximum validator now handles float comparison correctly
+
+Previously, maximum(10.5) would incorrectly reject 10.5 due to
+floating point comparison issue."
+```
+
+**Breaking Change (major bump)**:
+```bash
+git commit -m "feat!: migrate to Result monad from Maybe monad
+
+BREAKING CHANGE: All parsers now return Result[T, Error] instead of
+Maybe[T]. Success and Failure are renamed to Ok and Err.
+
+Migration guide:
+- Replace Success(val) with Ok(val)
+- Replace Failure(msg) with Err(Error(msg))
+- Update all .value_or() calls to handle new Error type"
+```
+
+**Documentation (patch bump)**:
+```bash
+git commit -m "docs: add comprehensive tutorial for custom validators"
+```
+
+**Chore (patch bump)**:
+```bash
+git commit -m "chore(deps): update pydantic to 2.10.0"
+```
+
+**Non-versioning commit**:
+```bash
+git commit -m "ci: add caching to GitHub Actions workflows"
+```
+
+### Development Workflow
+
+#### 1. Create a Feature Branch
+
+```bash
+git checkout -b feat/phone-number-parser
+```
+
+#### 2. Make Changes and Commit
+
+```bash
+# Make your changes
+vim valid8r/core/parsers.py
+
+# Add tests
+vim tests/unit/test_parsers.py
+
+# Run tests locally
+poetry run pytest
+
+# Commit with conventional format
+git add .
+git commit -m "feat(parsers): add parse_phone_number
+
+- Validates phone numbers using libphonenumber
+- Returns PhoneNumber structured type
+- Supports international formats"
+```
+
+#### 3. Push and Create PR
+
+```bash
+git push origin feat/phone-number-parser
+
+# Create PR using GitHub CLI
+gh pr create --title "feat(parsers): add parse_phone_number" --body "Adds phone number parsing with international support"
+```
+
+#### 4. CI Checks Run Automatically
+
+The CI workflow will:
+- Run linters (ruff, isort)
+- Run type checking (mypy)
+- Run tests on Python 3.11, 3.12, 3.13
+- Run BDD tests
+- Build documentation
+- Run smoke tests
+
+All checks must pass before merging.
+
+#### 5. Merge to Main
+
+```bash
+# Squash and merge (or merge) via GitHub UI
+# Ensure the final commit message follows conventional commits format
+```
+
+#### 6. Automatic Version Bump and Release
+
+After merge to `main`:
+1. `version-and-release.yml` analyzes commits since last tag
+2. Determines version bump (e.g., `feat:` → minor bump)
+3. Updates `pyproject.toml` version (e.g., `0.1.0` → `0.2.0`)
+4. Creates git tag `v0.2.0`
+5. Generates changelog from categorized commits
+6. Creates GitHub Release with notes
+
+#### 7. Automatic PyPI Publication
+
+After GitHub Release is created:
+1. `publish-pypi.yml` checks if version exists on PyPI
+2. Builds wheel and source distribution
+3. Tests the built package
+4. Publishes to PyPI
+5. Verifies publication
+
+### Manual Version Override
+
+If you need to manually trigger a version bump:
+
+```bash
+# Via GitHub UI: Actions → Version and Release → Run workflow
+# Select version bump type: major, minor, or patch
+
+# Or via GitHub CLI
+gh workflow run version-and-release.yml -f version_bump=minor
+```
+
+### Publishing to Test PyPI
+
+To test the publishing process without affecting production PyPI:
+
+```bash
+# Via GitHub UI: Actions → Publish to PyPI → Run workflow
+# Check "Publish to Test PyPI instead of PyPI"
+
+# Or via GitHub CLI
+gh workflow run publish-pypi.yml -f test_pypi=true
+```
+
+Then install from Test PyPI:
+```bash
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ valid8r
+```
+
+## Workflow Triggers Summary
+
+| Workflow | Automatic Triggers | Manual Trigger | When |
+|----------|-------------------|----------------|------|
+| CI | PR to main, Push to main | Yes | Every code change |
+| Version & Release | Push to main | Yes (with override) | After merge to main |
+| Publish to PyPI | Release published | Yes (with test mode) | After GitHub Release |
+
+## Versioning Strategy
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** version (X.0.0): Incompatible API changes
+- **MINOR** version (0.X.0): New functionality, backward compatible
+- **PATCH** version (0.0.X): Bug fixes, backward compatible
+
+### Pre-1.0.0 Exception
+
+While in `0.x.x` versions (pre-stable):
+- Breaking changes may be introduced in minor versions
+- Use `0.x.0` for significant features
+- Use `0.x.y` for patches and small features
+
+Once the API is stable, release `1.0.0` and follow strict semver.
+
+## Troubleshooting
+
+### Version Not Bumping
+
+**Problem**: Commits pushed to main but no version bump occurs.
+
+**Cause**: Commits don't follow conventional commits format.
+
+**Solution**: Ensure commit messages start with `feat:`, `fix:`, etc.
+
+```bash
+# Check recent commits
+git log --oneline -5
+
+# If needed, create a manual bump
+gh workflow run version-and-release.yml -f version_bump=patch
+```
+
+### PyPI Upload Failed: Version Already Exists
+
+**Problem**: Workflow fails with "File already exists" error.
+
+**Cause**: Version already published to PyPI (duplicate).
+
+**Solution**: This is expected behavior. The workflow skips publishing if the version exists. To publish a new version, merge more commits to trigger a version bump.
+
+### CI Checks Failing
+
+**Problem**: Unable to merge PR due to failing checks.
+
+**Solution**:
+1. Check workflow run logs in GitHub Actions tab
+2. Run same checks locally:
+   ```bash
+   poetry run ruff check .
+   poetry run ruff format --check .
+   poetry run mypy valid8r
+   poetry run pytest
+   poetry run behave tests/bdd/features
+   ```
+3. Fix issues and push again
+
+### Permission Denied on Git Push (workflow)
+
+**Problem**: Workflow fails to push version bump commit.
+
+**Cause**: Insufficient permissions for GITHUB_TOKEN.
+
+**Solution**:
+1. Go to `Settings` → `Actions` → `General`
+2. Set "Workflow permissions" to "Read and write permissions"
+3. ✅ "Allow GitHub Actions to create and approve pull requests"
+
+## Best Practices
+
+### Commit Messages
+- Use imperative mood: "add feature" not "added feature"
+- Keep first line under 72 characters
+- Reference issues: `fix(parser): handle null input (#123)`
+- Group related changes in one commit
+
+### Pull Requests
+- Keep PRs focused and small
+- Use conventional commits format for PR title
+- PR title becomes the squash commit message
+- Link related issues in PR description
+
+### Releases
+- Let the workflow handle versioning automatically
+- Review generated release notes before announcing
+- Update documentation for breaking changes
+- Consider deprecation warnings before breaking changes
+
+### Testing Before Release
+1. Create a feature branch
+2. Open PR to see CI results
+3. Merge to main (triggers version bump)
+4. Wait for GitHub Release
+5. Verify PyPI publication
+6. Test installation: `pip install valid8r`
+
+## CI/CD Architecture Diagram
+
+```
+┌─────────────────┐
+│  Pull Request   │
+└────────┬────────┘
+         │
+         ▼
+    ┌────────┐
+    │   CI   │ ◄── Lint, Type Check, Test (3.11, 3.12, 3.13), BDD, Docs
+    └────┬───┘
+         │ (All checks pass)
+         ▼
+    ┌─────────┐
+    │  Merge  │
+    │ to main │
+    └────┬────┘
+         │
+         ▼
+┌──────────────────┐
+│ Version & Release│ ◄── Analyze commits, bump version, create tag & release
+└────────┬─────────┘
+         │
+         ▼
+  ┌──────────────┐
+  │GitHub Release│
+  └──────┬───────┘
+         │
+         ▼
+┌─────────────────┐
+│ Publish to PyPI │ ◄── Build, test package, publish if new version
+└─────────────────┘
+```
+
+## Support and Issues
+
+If you encounter issues with the CI/CD workflows:
+
+1. Check workflow run logs in the "Actions" tab
+2. Review this documentation
+3. Open an issue with:
+   - Workflow name
+   - Run ID or link to failed run
+   - Error message
+   - Expected vs actual behavior
+
+## Additional Resources
+
+- [Conventional Commits Specification](https://www.conventionalcommits.org/)
+- [Semantic Versioning](https://semver.org/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [Poetry Publishing](https://python-poetry.org/docs/libraries/#publishing-to-pypi)
+- [PyPI Trusted Publishers](https://docs.pypi.org/trusted-publishers/)

--- a/.github/WORKFLOW_DIAGRAM.txt
+++ b/.github/WORKFLOW_DIAGRAM.txt
@@ -1,0 +1,209 @@
+GitHub Actions CI/CD Pipeline for valid8r
+==========================================
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                           DEVELOPER WORKFLOW                                 │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+1. Create Feature Branch
+   ┌──────────────────────────────────────────┐
+   │ git checkout -b feat/add-parser          │
+   └──────────────────────────────────────────┘
+                    ↓
+2. Make Changes & Commit (Conventional Format)
+   ┌──────────────────────────────────────────┐
+   │ git commit -m "feat: add UUID parser"    │
+   └──────────────────────────────────────────┘
+                    ↓
+3. Create Pull Request
+   ┌──────────────────────────────────────────┐
+   │ gh pr create --fill                      │
+   └──────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                         CI WORKFLOW (ci.yml)                                 │
+│                    Triggers: PR + Push to main                               │
+└─────────────────────────────────────────────────────────────────────────────┘
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Parallel Jobs (must all pass):                   │
+    │                                                    │
+    │  ┌──────────────┐  ┌──────────────┐  ┌─────────┐ │
+    │  │ Lint & Format│  │ Type Check   │  │  Docs   │ │
+    │  │  (ruff)      │  │   (mypy)     │  │ Build   │ │
+    │  └──────────────┘  └──────────────┘  └─────────┘ │
+    │                                                    │
+    │  ┌──────────────────────────────────────────────┐ │
+    │  │         Unit Tests (pytest)                  │ │
+    │  │  ┌─────────┐ ┌─────────┐ ┌─────────┐        │ │
+    │  │  │ Python  │ │ Python  │ │ Python  │        │ │
+    │  │  │  3.11   │ │  3.12   │ │  3.13   │        │ │
+    │  │  └─────────┘ └─────────┘ └─────────┘        │ │
+    │  └──────────────────────────────────────────────┘ │
+    │                                                    │
+    │  ┌──────────────┐  ┌──────────────┐              │
+    │  │  BDD Tests   │  │ Smoke Test   │              │
+    │  │  (behave)    │  │              │              │
+    │  └──────────────┘  └──────────────┘              │
+    └───────────────────────────────────────────────────┘
+                    ↓
+              All Checks Pass
+                    ↓
+4. Get Review & Merge to Main
+   ┌──────────────────────────────────────────┐
+   │ Squash & Merge (or Merge)                │
+   │ PR title: "feat: add UUID parser"        │
+   └──────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                  VERSION & RELEASE WORKFLOW                                  │
+│                  (version-and-release.yml)                                   │
+│                     Triggers: Push to main                                   │
+└─────────────────────────────────────────────────────────────────────────────┘
+                    ↓
+         Get Commits Since Last Tag
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Analyze Conventional Commits:                    │
+    │                                                    │
+    │  feat: → Minor bump (0.1.0 → 0.2.0)              │
+    │  fix:  → Patch bump (0.1.0 → 0.1.1)              │
+    │  docs: → Patch bump                               │
+    │  BREAKING CHANGE → Major (0.1.0 → 1.0.0)         │
+    │  ci:   → No bump                                  │
+    └───────────────────────────────────────────────────┘
+                    ↓
+         Determine Version Bump Type
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Update pyproject.toml:                           │
+    │  version = "0.2.0"                                │
+    └───────────────────────────────────────────────────┘
+                    ↓
+         Commit & Push Version Update
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Create Git Tag:                                  │
+    │  git tag -a v0.2.0                                │
+    │  git push origin v0.2.0                           │
+    └───────────────────────────────────────────────────┘
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Generate Changelog (categorized by type):        │
+    │  - Features                                       │
+    │  - Bug Fixes                                      │
+    │  - Documentation                                  │
+    │  - Performance                                    │
+    │  - Refactoring                                    │
+    │  - Tests                                          │
+    │  - Chores                                         │
+    │  - Breaking Changes                               │
+    └───────────────────────────────────────────────────┘
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Create GitHub Release:                           │
+    │  - Tag: v0.2.0                                    │
+    │  - Title: Release v0.2.0                          │
+    │  - Body: Generated changelog                      │
+    └───────────────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                    PUBLISH TO PYPI WORKFLOW                                  │
+│                     (publish-pypi.yml)                                       │
+│                Triggers: GitHub Release published                            │
+└─────────────────────────────────────────────────────────────────────────────┘
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Check if Version Exists on PyPI:                 │
+    │  curl https://pypi.org/pypi/valid8r/0.2.0/json    │
+    └───────────────────────────────────────────────────┘
+                    ↓
+         ┌────────────────────────┐
+         │ Already exists?        │
+         └────────────────────────┘
+          ↓ No              ↓ Yes
+     Continue          Skip (safety check)
+          ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Build Package:                                   │
+    │  poetry build                                     │
+    │  - Creates wheel: valid8r-0.2.0-py3-none-any.whl │
+    │  - Creates tarball: valid8r-0.2.0.tar.gz         │
+    └───────────────────────────────────────────────────┘
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Test Built Package:                              │
+    │  Install and test on:                             │
+    │  ┌─────────┐ ┌─────────┐ ┌─────────┐            │
+    │  │ Python  │ │ Python  │ │ Python  │            │
+    │  │  3.11   │ │  3.12   │ │  3.13   │            │
+    │  └─────────┘ └─────────┘ └─────────┘            │
+    │  - Import validation                              │
+    │  - Smoke tests                                    │
+    └───────────────────────────────────────────────────┘
+                    ↓
+              All Tests Pass
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Publish to PyPI:                                 │
+    │  poetry publish                                   │
+    │  Using: PYPI_API_TOKEN secret                     │
+    │  skip-existing: true (safety)                     │
+    └───────────────────────────────────────────────────┘
+                    ↓
+    ┌───────────────────────────────────────────────────┐
+    │  Verify Publication:                              │
+    │  pip install valid8r==0.2.0                       │
+    │  python -c "import valid8r"                       │
+    └───────────────────────────────────────────────────┘
+                    ↓
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                              SUCCESS!                                        │
+│                                                                              │
+│  ✓ Code tested and validated                                                │
+│  ✓ Version bumped automatically                                             │
+│  ✓ GitHub Release created with changelog                                    │
+│  ✓ Package published to PyPI                                                │
+│  ✓ Available for installation: pip install valid8r                          │
+└─────────────────────────────────────────────────────────────────────────────┘
+
+
+CONVENTIONAL COMMIT EXAMPLES:
+=============================
+
+feat(parsers): add UUID validation
+→ Minor bump: 0.1.0 → 0.2.0
+
+fix(validators): handle None values correctly
+→ Patch bump: 0.1.0 → 0.1.1
+
+docs: add examples to README
+→ Patch bump: 0.1.0 → 0.1.1
+
+feat!: redesign validation API
+→ Major bump: 0.1.0 → 1.0.0
+
+ci: update Python versions in test matrix
+→ No version bump
+
+
+MANUAL TRIGGERS:
+================
+
+# Override automatic version detection
+gh workflow run version-and-release.yml -f version_bump=minor
+
+# Test publishing to Test PyPI
+gh workflow run publish-pypi.yml -f test_pypi=true
+
+# Trigger CI manually
+gh workflow run ci.yml
+
+
+WORKFLOW STATUS:
+================
+
+View runs:    https://github.com/mikelane/valid8r/actions
+View releases: https://github.com/mikelane/valid8r/releases
+View on PyPI:  https://pypi.org/project/valid8r/
+

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,235 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      test_pypi:
+        description: 'Publish to Test PyPI instead of PyPI'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-version:
+    name: Check Version Not Already Published
+    runs-on: ubuntu-latest
+    outputs:
+      should_publish: ${{ steps.check.outputs.should_publish }}
+      version: ${{ steps.get_version.outputs.version }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+
+      - name: Get package version
+        id: get_version
+        run: |
+          VERSION=$(poetry version -s)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Package version: $VERSION"
+
+      - name: Check if version exists on PyPI
+        id: check
+        run: |
+          VERSION="${{ steps.get_version.outputs.version }}"
+          PACKAGE_NAME="valid8r"
+
+          # Check if version exists on PyPI
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/$PACKAGE_NAME/$VERSION/json")
+
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "Version $VERSION already exists on PyPI"
+            echo "should_publish=false" >> $GITHUB_OUTPUT
+          else
+            echo "Version $VERSION not found on PyPI, will publish"
+            echo "should_publish=true" >> $GITHUB_OUTPUT
+          fi
+
+  build:
+    name: Build Distribution
+    needs: check-version
+    if: needs.check-version.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Install dependencies
+        run: poetry install --no-interaction
+
+      - name: Build package
+        run: poetry build
+
+      - name: List built files
+        run: |
+          echo "Built distributions:"
+          ls -lh dist/
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+          retention-days: 7
+
+  test-built-package:
+    name: Test Built Package
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12', '3.13']
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Install wheel
+        run: |
+          pip install dist/*.whl
+
+      - name: Test import
+        run: |
+          python -c "import valid8r; print(f'valid8r imported successfully')"
+          python -c "from valid8r import parsers, validators, Maybe; print('Core imports successful')"
+
+      - name: Run smoke tests
+        run: |
+          python << 'EOF'
+          from valid8r import parsers, validators
+          from valid8r.core.maybe import Success, Failure
+
+          # Test basic parsing
+          result = parsers.parse_int("42")
+          assert isinstance(result, Success)
+          assert result.value_or(0) == 42
+
+          # Test validation
+          validator = validators.minimum(0) & validators.maximum(100)
+          result = validator(50)
+          assert isinstance(result, Success)
+
+          print("Smoke tests passed!")
+          EOF
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [check-version, build, test-built-package]
+    if: |
+      needs.check-version.outputs.should_publish == 'true' &&
+      github.event.inputs.test_pypi != 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/valid8r
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          skip-existing: true
+          verbose: true
+
+      - name: Verify publication
+        run: |
+          VERSION="${{ needs.check-version.outputs.version }}"
+          echo "Waiting for package to be available on PyPI..."
+          sleep 30
+
+          # Try to install from PyPI
+          pip install valid8r==$VERSION
+          python -c "import valid8r; print(f'Successfully installed valid8r {valid8r.__version__ if hasattr(valid8r, \"__version__\") else VERSION}')"
+
+  publish-test-pypi:
+    name: Publish to Test PyPI
+    needs: [check-version, build, test-built-package]
+    if: |
+      needs.check-version.outputs.should_publish == 'true' &&
+      github.event.inputs.test_pypi == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: test-pypi
+      url: https://test.pypi.org/p/valid8r
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
+          verbose: true
+
+  notify-slack:
+    name: Notify Release
+    needs: [publish-pypi, check-version]
+    if: always() && needs.check-version.outputs.should_publish == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Notify success
+        if: needs.publish-pypi.result == 'success'
+        run: |
+          echo "Successfully published valid8r v${{ needs.check-version.outputs.version }} to PyPI!"
+          echo "View at: https://pypi.org/project/valid8r/${{ needs.check-version.outputs.version }}/"
+
+      - name: Notify failure
+        if: needs.publish-pypi.result == 'failure'
+        run: |
+          echo "Failed to publish valid8r v${{ needs.check-version.outputs.version }} to PyPI"
+          exit 1

--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -1,0 +1,205 @@
+name: Version and Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version_bump:
+        description: 'Version bump type (major, minor, patch, or leave empty for auto-detect)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  version-and-release:
+    name: Determine Version and Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      new_version: ${{ steps.version.outputs.new_version }}
+      version_changed: ${{ steps.version.outputs.version_changed }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Get current version
+        id: current_version
+        run: |
+          CURRENT_VERSION=$(poetry version -s)
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Get latest tag
+        id: latest_tag
+        run: |
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest tag: $LATEST_TAG"
+
+      - name: Analyze commits for version bump
+        id: analyze
+        run: |
+          # Get commits since last tag
+          LATEST_TAG="${{ steps.latest_tag.outputs.latest_tag }}"
+
+          if [ "$LATEST_TAG" = "v0.0.0" ]; then
+            COMMITS=$(git log --pretty=format:"%s" main)
+          else
+            COMMITS=$(git log --pretty=format:"%s" ${LATEST_TAG}..HEAD)
+          fi
+
+          echo "Analyzing commits:"
+          echo "$COMMITS"
+
+          # Check for breaking changes (BREAKING CHANGE: or !)
+          if echo "$COMMITS" | grep -iE "^[a-z]+(\(.+\))?!:|BREAKING CHANGE:" > /dev/null; then
+            echo "bump_type=major" >> $GITHUB_OUTPUT
+            echo "Detected: MAJOR (breaking changes)"
+          # Check for features (feat:)
+          elif echo "$COMMITS" | grep -iE "^feat(\(.+\))?:" > /dev/null; then
+            echo "bump_type=minor" >> $GITHUB_OUTPUT
+            echo "Detected: MINOR (new features)"
+          # Check for fixes, chores, docs, etc.
+          elif echo "$COMMITS" | grep -iE "^(fix|chore|docs|style|refactor|perf|test)(\(.+\))?:" > /dev/null; then
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
+            echo "Detected: PATCH (fixes/chores)"
+          else
+            echo "bump_type=none" >> $GITHUB_OUTPUT
+            echo "No conventional commits found - skipping version bump"
+          fi
+
+      - name: Determine version bump
+        id: version
+        run: |
+          MANUAL_BUMP="${{ github.event.inputs.version_bump }}"
+          AUTO_BUMP="${{ steps.analyze.outputs.bump_type }}"
+
+          # Manual bump takes precedence
+          if [ -n "$MANUAL_BUMP" ]; then
+            BUMP_TYPE="$MANUAL_BUMP"
+            echo "Using manual bump type: $BUMP_TYPE"
+          else
+            BUMP_TYPE="$AUTO_BUMP"
+            echo "Using auto-detected bump type: $BUMP_TYPE"
+          fi
+
+          if [ "$BUMP_TYPE" = "none" ]; then
+            echo "version_changed=false" >> $GITHUB_OUTPUT
+            echo "No version bump needed"
+            exit 0
+          fi
+
+          # Bump version using poetry
+          echo "Bumping version: $BUMP_TYPE"
+          poetry version $BUMP_TYPE
+
+          NEW_VERSION=$(poetry version -s)
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "version_changed=true" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+
+      - name: Commit version bump
+        if: steps.version.outputs.version_changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+
+          git add pyproject.toml
+          git commit -m "chore: bump version to $NEW_VERSION"
+          git push
+
+      - name: Create git tag
+        if: steps.version.outputs.version_changed == 'true'
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
+          git push origin "v$NEW_VERSION"
+
+      - name: Generate changelog
+        if: steps.version.outputs.version_changed == 'true'
+        id: changelog
+        run: |
+          LATEST_TAG="${{ steps.latest_tag.outputs.latest_tag }}"
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+
+          echo "# Release v$NEW_VERSION" > RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          # Get commits since last tag
+          if [ "$LATEST_TAG" = "v0.0.0" ]; then
+            COMMITS=$(git log --pretty=format:"%s|%h|%an" main)
+          else
+            COMMITS=$(git log --pretty=format:"%s|%h|%an" ${LATEST_TAG}..v${NEW_VERSION})
+          fi
+
+          # Categorize commits
+          echo "## Features" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^feat(\(.+\))?:" | sed 's/^feat\(([^)]*)\)\?: /- **\1:** /' | sed 's/^feat: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Bug Fixes" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^fix(\(.+\))?:" | sed 's/^fix\(([^)]*)\)\?: /- **\1:** /' | sed 's/^fix: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Documentation" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^docs(\(.+\))?:" | sed 's/^docs\(([^)]*)\)\?: /- **\1:** /' | sed 's/^docs: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Performance Improvements" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^perf(\(.+\))?:" | sed 's/^perf\(([^)]*)\)\?: /- **\1:** /' | sed 's/^perf: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Refactoring" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^refactor(\(.+\))?:" | sed 's/^refactor\(([^)]*)\)\?: /- **\1:** /' | sed 's/^refactor: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Testing" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^test(\(.+\))?:" | sed 's/^test\(([^)]*)\)\?: /- **\1:** /' | sed 's/^test: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Chores" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^chore(\(.+\))?:" | sed 's/^chore\(([^)]*)\)\?: /- **\1:** /' | sed 's/^chore: /- /' || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          echo "## Breaking Changes" >> RELEASE_NOTES.md
+          echo "$COMMITS" | grep -iE "^[a-z]+(\(.+\))?!:|BREAKING CHANGE:" || echo "None" >> RELEASE_NOTES.md
+          echo "" >> RELEASE_NOTES.md
+
+          cat RELEASE_NOTES.md
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.version_changed == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.version.outputs.new_version }}
+          name: Release v${{ steps.version.outputs.new_version }}
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: false
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CICD_SETUP_SUMMARY.md
+++ b/CICD_SETUP_SUMMARY.md
@@ -1,0 +1,513 @@
+# CI/CD Setup Summary for valid8r
+
+This document provides a comprehensive summary of the GitHub Actions CI/CD workflows that have been set up for the valid8r Python package.
+
+## Overview
+
+A complete CI/CD pipeline has been configured that automates:
+- Code quality checks (linting, type checking, testing)
+- Semantic versioning based on conventional commits
+- GitHub releases with auto-generated changelogs
+- PyPI package publishing
+
+## Files Created
+
+### Workflow Files (`.github/workflows/`)
+
+1. **`ci.yml`** (existing, confirmed working)
+   - Runs on every PR and push to main
+   - Executes linting, type checking, unit tests, BDD tests, docs build, and smoke tests
+   - Tests against Python 3.11, 3.12, and 3.13
+   - Location: `/Users/mikelane/dev/valid8r/.github/workflows/ci.yml`
+
+2. **`version-and-release.yml`** (newly created)
+   - Runs on every push to main
+   - Analyzes commits using conventional commits format
+   - Automatically bumps version in `pyproject.toml`
+   - Creates git tags and GitHub releases
+   - Generates categorized changelog
+   - Location: `/Users/mikelane/dev/valid8r/.github/workflows/version-and-release.yml`
+
+3. **`publish-pypi.yml`** (newly created)
+   - Runs when GitHub release is published
+   - Checks if version already exists on PyPI (prevents duplicates)
+   - Builds wheel and source distribution
+   - Tests built package on all Python versions
+   - Publishes to PyPI automatically
+   - Location: `/Users/mikelane/dev/valid8r/.github/workflows/publish-pypi.yml`
+
+### Documentation Files (`.github/`)
+
+4. **`WORKFLOWS.md`**
+   - Complete guide to all workflows
+   - Detailed explanation of triggers, jobs, and processes
+   - Developer workflow guide
+   - Conventional commits specification
+   - Troubleshooting guide
+   - Location: `/Users/mikelane/dev/valid8r/.github/WORKFLOWS.md`
+
+5. **`CONVENTIONAL_COMMITS.md`**
+   - Quick reference for commit message format
+   - Examples for every commit type
+   - Version bump rules
+   - Decision tree for choosing commit types
+   - Anti-patterns to avoid
+   - Location: `/Users/mikelane/dev/valid8r/.github/CONVENTIONAL_COMMITS.md`
+
+6. **`SETUP_CHECKLIST.md`**
+   - Step-by-step repository setup guide
+   - PyPI account and token configuration
+   - GitHub secrets setup
+   - Branch protection configuration
+   - Testing procedures
+   - Troubleshooting common issues
+   - Location: `/Users/mikelane/dev/valid8r/.github/SETUP_CHECKLIST.md`
+
+7. **`README.md`** (`.github` directory)
+   - Overview of all GitHub configuration
+   - Quick links to documentation
+   - Summary of workflows
+   - Quick start for contributors
+   - Location: `/Users/mikelane/dev/valid8r/.github/README.md`
+
+## Required Secrets Setup
+
+Before the workflows can publish to PyPI, you need to configure GitHub secrets:
+
+### Step 1: Create PyPI API Token
+
+1. Go to https://pypi.org/account/register/ and create an account (if needed)
+2. Enable 2FA (required for API tokens)
+3. Go to https://pypi.org/manage/account/token/
+4. Click "Add API token"
+   - Name: `github-actions-valid8r`
+   - Scope: "Entire account" (change to project scope after first publish)
+5. Copy the token (starts with `pypi-`) - you won't see it again!
+
+### Step 2: Add Secret to GitHub
+
+1. Go to https://github.com/mikelane/valid8r/settings/secrets/actions
+2. Click "New repository secret"
+3. Name: `PYPI_API_TOKEN`
+4. Value: Paste the token from step 1
+5. Click "Add secret"
+
+### Step 3: Configure GitHub Actions Permissions
+
+1. Go to https://github.com/mikelane/valid8r/settings/actions
+2. Under "Workflow permissions":
+   - Select "Read and write permissions"
+   - Check "Allow GitHub Actions to create and approve pull requests"
+3. Click "Save"
+
+### Optional: Test PyPI Token
+
+For testing before publishing to production PyPI:
+
+1. Create Test PyPI account: https://test.pypi.org/account/register/
+2. Generate API token (same process as above)
+3. Add `TEST_PYPI_API_TOKEN` secret to GitHub
+
+## How It Works
+
+### Workflow 1: Continuous Integration (Existing)
+
+```
+Pull Request Created → CI Workflow Triggers
+                       ├── Lint Check (ruff)
+                       ├── Format Check (ruff)
+                       ├── Type Check (mypy)
+                       ├── Unit Tests (pytest on 3.11, 3.12, 3.13)
+                       ├── BDD Tests (behave)
+                       ├── Documentation Build
+                       └── Smoke Test
+                            ↓
+                       All Checks Pass → Ready to Merge
+```
+
+### Workflow 2: Version and Release (New)
+
+```
+Merge to Main → Version & Release Workflow Triggers
+                ↓
+             Analyze Commits Since Last Tag
+                ↓
+             Determine Version Bump:
+             - feat: → Minor (0.1.0 → 0.2.0)
+             - fix:/docs:/etc. → Patch (0.1.0 → 0.1.1)
+             - BREAKING CHANGE → Major (0.1.0 → 1.0.0)
+                ↓
+             Update pyproject.toml
+                ↓
+             Commit & Push Version Bump
+                ↓
+             Create Git Tag (v0.2.0)
+                ↓
+             Generate Changelog from Commits
+                ↓
+             Create GitHub Release
+```
+
+### Workflow 3: Publish to PyPI (New)
+
+```
+GitHub Release Published → Publish Workflow Triggers
+                          ↓
+                       Check Version on PyPI
+                          ↓
+                    Version Already Exists?
+                    ├── Yes → Skip (no duplicate)
+                    └── No → Continue
+                              ↓
+                          Build Package (wheel + sdist)
+                              ↓
+                          Test Built Package on 3.11, 3.12, 3.13
+                              ↓
+                          Publish to PyPI
+                              ↓
+                          Verify Publication
+```
+
+## Conventional Commits Format
+
+All commits must follow this format to trigger automatic versioning:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer]
+```
+
+### Version Bump Rules
+
+| Commit Type | Example | Version Bump |
+|-------------|---------|--------------|
+| `feat:` | `feat: add UUID parsing` | 0.1.0 → 0.2.0 (minor) |
+| `fix:` | `fix: handle None in validator` | 0.1.0 → 0.1.1 (patch) |
+| `docs:` | `docs: update README` | 0.1.0 → 0.1.1 (patch) |
+| `refactor:` | `refactor: simplify parser` | 0.1.0 → 0.1.1 (patch) |
+| `perf:` | `perf: optimize validation` | 0.1.0 → 0.1.1 (patch) |
+| `test:` | `test: add edge cases` | 0.1.0 → 0.1.1 (patch) |
+| `chore:` | `chore: update deps` | 0.1.0 → 0.1.1 (patch) |
+| `ci:` | `ci: update workflow` | No bump |
+| `feat!:` or `BREAKING CHANGE:` | `feat!: redesign API` | 0.1.0 → 1.0.0 (major) |
+
+### Examples
+
+**Feature (minor bump)**:
+```bash
+git commit -m "feat(parsers): add phone number validation
+
+Supports international formats using E.164 standard.
+Returns PhoneNumber structured type."
+```
+
+**Bug Fix (patch bump)**:
+```bash
+git commit -m "fix(validators): maximum validator now handles floats correctly"
+```
+
+**Breaking Change (major bump)**:
+```bash
+git commit -m "feat!: migrate to Result monad
+
+BREAKING CHANGE: All parsers now return Result[T, Error] instead of Maybe[T].
+See migration guide in docs."
+```
+
+**Documentation (patch bump)**:
+```bash
+git commit -m "docs: add tutorial for custom validators"
+```
+
+**No version bump**:
+```bash
+git commit -m "ci: add Python 3.14 to test matrix"
+```
+
+## Developer Workflow
+
+### Making Changes
+
+1. **Create feature branch**:
+   ```bash
+   git checkout -b feat/add-parser
+   ```
+
+2. **Make changes and commit** (using conventional format):
+   ```bash
+   git add .
+   git commit -m "feat(parsers): add IP address validation"
+   ```
+
+3. **Push and create PR**:
+   ```bash
+   git push origin feat/add-parser
+   gh pr create --fill
+   ```
+
+4. **Wait for CI checks** - All must pass before merging
+
+5. **Get review approval and merge**
+
+6. **Automatic version bump** - Happens when merged to main
+
+7. **Automatic PyPI publish** - Happens after GitHub release is created
+
+### What Happens After Merge
+
+When you merge a PR with a `feat:` commit:
+
+1. **Version bump workflow runs**:
+   - Detects `feat:` commit
+   - Bumps minor version (e.g., 0.1.0 → 0.2.0)
+   - Updates `pyproject.toml`
+   - Commits the change
+   - Creates tag `v0.2.0`
+   - Generates changelog
+   - Creates GitHub Release
+
+2. **PyPI publish workflow runs**:
+   - Triggered by the GitHub Release
+   - Checks if v0.2.0 exists on PyPI
+   - Builds the package
+   - Tests it on all Python versions
+   - Publishes to PyPI
+   - Package is now available: `pip install valid8r==0.2.0`
+
+## Manual Operations
+
+### Manual Version Bump
+
+If you need to override automatic version detection:
+
+```bash
+# Trigger minor version bump manually
+gh workflow run version-and-release.yml -f version_bump=minor
+
+# Or major/patch
+gh workflow run version-and-release.yml -f version_bump=major
+gh workflow run version-and-release.yml -f version_bump=patch
+```
+
+### Test PyPI Publishing
+
+To test the publishing workflow without affecting production:
+
+```bash
+# Publish to Test PyPI
+gh workflow run publish-pypi.yml -f test_pypi=true
+
+# Then test installation
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ valid8r
+```
+
+## Testing the Setup
+
+### Before First Production Release
+
+1. **Test with Test PyPI**:
+   ```bash
+   # First, ensure version in pyproject.toml is something like 0.1.0-alpha1
+   poetry version 0.1.0-alpha1
+
+   # Commit and push
+   git add pyproject.toml
+   git commit -m "chore: set alpha version for testing"
+   git push
+
+   # Manually trigger test publish
+   gh workflow run publish-pypi.yml -f test_pypi=true
+   ```
+
+2. **Verify test publish**:
+   ```bash
+   # Install from Test PyPI
+   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ valid8r
+
+   # Test import
+   python -c "from valid8r import parsers; print(parsers.parse_int('42'))"
+   ```
+
+3. **Reset to production version**:
+   ```bash
+   poetry version 0.1.0
+   git add pyproject.toml
+   git commit -m "chore: reset to production version"
+   git push
+   ```
+
+### First Production Release
+
+1. **Create a feature to trigger version bump**:
+   ```bash
+   git checkout -b feat/initial-release
+   # Make a small change or update docs
+   git commit -m "feat: initial PyPI release"
+   git push origin feat/initial-release
+   gh pr create --title "feat: initial PyPI release" --body "First production release to PyPI"
+   ```
+
+2. **Merge PR** - This will trigger:
+   - Version bump (0.1.0 → 0.2.0)
+   - GitHub Release creation
+   - PyPI publishing
+
+3. **Verify release**:
+   - Check https://github.com/mikelane/valid8r/releases
+   - Check https://pypi.org/project/valid8r/
+   - Test: `pip install valid8r`
+
+## Monitoring and Maintenance
+
+### Check Workflow Status
+
+- View all workflow runs: https://github.com/mikelane/valid8r/actions
+- Check latest releases: https://github.com/mikelane/valid8r/releases
+- Monitor PyPI: https://pypi.org/project/valid8r/
+
+### Regular Maintenance
+
+- **Monthly**: Review failed workflows and fix issues
+- **Quarterly**: Update Python versions in test matrix
+- **Semi-annually**: Rotate PyPI API tokens
+- **Annually**: Review and update branch protection rules
+
+## Troubleshooting
+
+### Issue: Version Not Bumping
+
+**Symptom**: Merged to main but no version bump occurred
+
+**Cause**: Commits don't follow conventional format
+
+**Solution**:
+```bash
+# Check recent commits
+git log --oneline -5
+
+# If needed, trigger manual bump
+gh workflow run version-and-release.yml -f version_bump=patch
+```
+
+### Issue: PyPI Publishing Failed - 403 Forbidden
+
+**Cause**: API token issue
+
+**Solutions**:
+1. Check token is correctly set in GitHub secrets
+2. Ensure PyPI account has 2FA enabled
+3. Verify token hasn't expired
+4. Regenerate token and update secret if needed
+
+### Issue: PyPI Publishing Skipped - Version Exists
+
+**Symptom**: Workflow says "Version already exists on PyPI"
+
+**Cause**: This is expected behavior - prevents duplicate uploads
+
+**Solution**: This is normal. To publish new version, make new commits and merge to trigger version bump
+
+### Issue: CI Checks Failing
+
+**Solution**: Run checks locally:
+```bash
+poetry run ruff check .
+poetry run ruff format --check .
+poetry run mypy valid8r
+poetry run pytest
+poetry run behave tests/bdd/features
+```
+
+Fix issues and push again.
+
+### Issue: Permission Denied in Workflow
+
+**Symptom**: Workflow fails to push commits or create tags
+
+**Solution**:
+1. Go to Settings → Actions → General
+2. Set "Workflow permissions" to "Read and write permissions"
+3. Enable "Allow GitHub Actions to create and approve pull requests"
+
+## Security Best Practices
+
+1. **Never commit secrets** - Always use GitHub encrypted secrets
+2. **Rotate tokens regularly** - Every 6 months minimum
+3. **Use scoped tokens** - After first publish, change PyPI token to project-scoped
+4. **Enable 2FA** - Required on PyPI account
+5. **Branch protection** - Prevent force pushes and require reviews
+6. **Review workflow runs** - Monitor for suspicious activity
+
+## Documentation Reference
+
+All documentation is in the `.github/` directory:
+
+- **[.github/WORKFLOWS.md](file:///Users/mikelane/dev/valid8r/.github/WORKFLOWS.md)** - Complete workflows documentation (30+ pages)
+- **[.github/CONVENTIONAL_COMMITS.md](file:///Users/mikelane/dev/valid8r/.github/CONVENTIONAL_COMMITS.md)** - Commit message quick reference
+- **[.github/SETUP_CHECKLIST.md](file:///Users/mikelane/dev/valid8r/.github/SETUP_CHECKLIST.md)** - Step-by-step setup guide
+- **[.github/README.md](file:///Users/mikelane/dev/valid8r/.github/README.md)** - GitHub configuration overview
+
+## Next Steps
+
+### Immediate (Required for Publishing)
+
+1. **Create PyPI account** and generate API token
+2. **Add `PYPI_API_TOKEN`** to GitHub repository secrets
+3. **Configure Actions permissions** (read/write)
+4. **Test with Test PyPI** (optional but recommended)
+
+### Short-term (Within First Week)
+
+1. **Configure branch protection** rules on main
+2. **Test the complete workflow** with a real feature
+3. **Share documentation** with team members
+4. **Set up Codecov** (optional, for coverage reporting)
+
+### Long-term (Ongoing)
+
+1. **Monitor releases** and ensure smooth operation
+2. **Update documentation** as workflows evolve
+3. **Rotate API tokens** every 6 months
+4. **Review and improve** based on team feedback
+
+## Support
+
+**Questions or issues?**
+
+1. Check the documentation in `.github/` directory
+2. Review workflow logs in the Actions tab
+3. Check this summary document
+4. Open an issue with details
+
+## Success Criteria
+
+You'll know the setup is working when:
+
+- ✅ CI runs on every PR and all checks pass
+- ✅ Merging to main creates a new version and release
+- ✅ GitHub releases appear at https://github.com/mikelane/valid8r/releases
+- ✅ Package publishes to PyPI automatically
+- ✅ You can install with `pip install valid8r`
+- ✅ Version in PyPI matches version in pyproject.toml
+
+## Summary
+
+This CI/CD pipeline provides:
+
+- **Automated quality checks** - Catch bugs before they reach production
+- **Semantic versioning** - Consistent, predictable version numbers
+- **Automatic releases** - No manual steps needed
+- **PyPI publishing** - Package available immediately after merge
+- **Safety checks** - Prevents duplicates and validates before publishing
+- **Full transparency** - All changes tracked in git and releases
+
+The entire process from PR to PyPI is fully automated, requiring only that developers follow conventional commit format. This ensures consistent quality, reduces manual work, and makes releases predictable and reliable.
+
+---
+
+**Setup Status**: Workflows configured ✓ | Documentation complete ✓ | Ready for secrets configuration
+
+**Next Action**: Follow [SETUP_CHECKLIST.md](file:///Users/mikelane/dev/valid8r/.github/SETUP_CHECKLIST.md) to complete repository setup.


### PR DESCRIPTION
## Summary
Add complete CI/CD automation for semantic versioning and PyPI publishing.

## What's included
- **Version & Release workflow**: Automatically bumps version based on conventional commits and creates GitHub releases
- **PyPI Publishing workflow**: Builds and publishes package to PyPI on release creation  
- **Comprehensive documentation**: Setup guides, workflow diagrams, troubleshooting, and quick reference

## Workflows
1. `version-and-release.yml`: Triggered on push to main, analyzes commits, bumps version, creates release
2. `publish-pypi.yml`: Triggered on release creation, runs tests, builds package, publishes to PyPI

## Expected behavior after merge
1. This PR gets merged to main
2. Version bumps from 0.1.0 to 0.2.0 (feat: triggers minor bump)
3. GitHub Release created with changelog
4. Package published to PyPI
5. Available via: `pip install valid8r==0.2.0`

## Testing
PyPI token has been configured in GitHub secrets and all prerequisites are met.