### PR TITLE
fix: update version workflow to use PR-based approach

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -18,7 +18,7 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   version-and-release:
@@ -122,22 +122,65 @@ jobs:
           echo "version_changed=true" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
-      - name: Commit version bump
+      - name: Create version bump PR
         if: steps.version.outputs.version_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          BRANCH_NAME="chore/bump-version-to-$NEW_VERSION"
 
+          # Create and checkout new branch
+          git checkout -b "$BRANCH_NAME"
+
+          # Commit version bump
           git add pyproject.toml
           git commit -m "chore: bump version to $NEW_VERSION"
-          git push
 
-      - name: Create git tag
+          # Push branch
+          git push origin "$BRANCH_NAME"
+
+          # Create PR and auto-merge
+          gh pr create \
+            --title "chore: bump version to $NEW_VERSION" \
+            --body "Automated version bump to $NEW_VERSION based on conventional commits." \
+            --base main \
+            --head "$BRANCH_NAME"
+
+          # Wait a moment for PR to be created
+          sleep 2
+
+          # Merge the PR
+          gh pr merge "$BRANCH_NAME" --squash --auto --delete-branch
+
+      - name: Wait for PR merge and create git tag
         if: steps.version.outputs.version_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          BRANCH_NAME="chore/bump-version-to-$NEW_VERSION"
+
+          # Wait for PR to be merged (check every 5 seconds for up to 2 minutes)
+          echo "Waiting for PR to be merged..."
+          for i in {1..24}; do
+            if ! git ls-remote --heads origin "$BRANCH_NAME" | grep -q "$BRANCH_NAME"; then
+              echo "PR merged successfully"
+              break
+            fi
+            echo "Waiting for merge... (attempt $i/24)"
+            sleep 5
+          done
+
+          # Fetch latest main with the version bump
+          git fetch origin main
+          git checkout main
+          git pull origin main
+
+          # Create and push tag
           git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
           git push origin "v$NEW_VERSION"
 


### PR DESCRIPTION
## Problem
The version-and-release workflow failed because it attempted to push directly to main, which is protected by branch protection rules requiring PRs.

## Solution
Modified the workflow to:
1. Create a PR with the version bump (instead of direct push)
2. Auto-merge that PR using `gh pr merge --auto`
3. Wait for the PR to be merged
4. Then create the git tag and release

## Why this works
- GitHub Actions can create and merge its own PRs
- This respects branch protection while still automating the process
- The `--auto` flag queues the merge for when CI passes

## Testing
After merge, this workflow will be triggered and should successfully:
- Detect version bump from conventional commits
- Create a version bump PR
- Auto-merge it
- Create release v0.2.0
- Trigger PyPI publishing