### PR TITLE
docs: add Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# Read the Docs configuration file for Valid8r
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_create_environment:
+      # Install poetry
+      - pip install poetry
+    post_install:
+      # Install dependencies with poetry
+      - poetry config virtualenvs.create false
+      - poetry install --with docs --no-interaction
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+# Build documentation formats
+formats:
+  - pdf
+  - epub
+
+# Optional: python configuration
+python:
+  install:
+    - method: pip
+      path: .


### PR DESCRIPTION
## Summary
Adds `.readthedocs.yaml` configuration file to enable automated documentation builds on readthedocs.io.

## Changes
- Created `.readthedocs.yaml` with:
  - Python 3.11 build environment
  - Poetry for dependency management
  - Sphinx documentation with autoapi extension
  - PDF and EPUB format generation
  - Documentation built from `docs/` directory

## Testing
- ✅ Documentation builds successfully locally with `poetry run tox -e docs`
- ✅ All linters and formatters pass

## Next Steps
After merging this PR:
1. Import the repository on readthedocs.io
2. Connect GitHub account
3. Trigger initial build
4. Configure project settings (version management, webhooks)

Documentation will be available at: https://valid8r.readthedocs.io