### PR TITLE
fix: correct Read the Docs Poetry installation order

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,9 +13,10 @@ build:
     post_create_environment:
       # Install poetry
       - pip install poetry
-    post_install:
-      # Install dependencies with poetry
+      # Configure poetry to not create virtualenvs
       - poetry config virtualenvs.create false
+    post_install:
+      # Install all dependencies including the project itself
       - poetry install --with docs --no-interaction
 
 # Build documentation in the "docs/" directory with Sphinx
@@ -27,9 +28,3 @@ sphinx:
 formats:
   - pdf
   - epub
-
-# Optional: python configuration
-python:
-  install:
-    - method: pip
-      path: .


### PR DESCRIPTION
## Problem
Read the Docs build was failing with:
```
ModuleNotFoundError: No module named 'sphinx_autodoc_typehints'
```

## Root Cause
The `.readthedocs.yaml` configuration had both:
1. `python.install` section (runs pip install first)
2. `post_install` job (runs poetry install after)

This meant pip tried to install the package BEFORE Poetry had installed the documentation dependencies, causing Sphinx to fail when it couldn't find required extensions.

## Solution
- Removed the `python.install` section entirely
- Moved `poetry config virtualenvs.create false` to `post_create_environment`
- Let Poetry handle all installation (including the project itself) in `post_install`

This ensures dependencies are installed in the correct order:
1. Poetry installs all dependencies (including docs group)
2. Poetry installs the project itself
3. Sphinx can now find all required extensions

## Testing
- ✅ Configuration syntax validated
- ✅ Will verify build succeeds on Read the Docs after merge

Fixes the RTD build failure reported in the conversation.