### PR TITLE
fix: use poetry to run sphinx-build in RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,11 +18,9 @@ build:
     post_install:
       # Install all dependencies including the project itself
       - poetry install --with docs --no-interaction
-
-# Build documentation in the "docs/" directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
-  fail_on_warning: false
+  commands:
+    # Let Poetry run Sphinx to avoid dependency conflicts
+    - poetry run sphinx-build -b html docs $READTHEDOCS_OUTPUT/html
 
 # Build documentation formats
 formats:


### PR DESCRIPTION
## Problem

Read the Docs was failing to build documentation with:
```
ModuleNotFoundError: No module named 'sphinx_autodoc_typehints'
```

The issue occurred because RTD's default behavior is to install Sphinx separately before running Poetry's post_install jobs. This created a dependency mismatch where Sphinx extensions installed by Poetry weren't available to RTD's separate Sphinx installation.

## Solution

This PR modifies `.readthedocs.yaml` to:
1. Remove the `sphinx:` configuration section
2. Add a custom `build.commands` section that runs `poetry run sphinx-build`

This ensures Poetry manages the entire build process, including Sphinx and all its extensions, eliminating the dependency conflict.

## Changes

- `.readthedocs.yaml`: Replaced `sphinx:` section with `build.commands` that uses Poetry

## Testing

The RTD build will be triggered automatically when this PR is merged. We expect the build to succeed with all Sphinx extensions available.