### PR TITLE
fix: trigger PyPI publish workflow after creating release

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -246,3 +246,16 @@ jobs:
           draft: false
           prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger PyPI Publish Workflow
+        if: steps.version.outputs.version_changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Wait a moment for the release to be fully created
+          sleep 5
+
+          # Trigger the publish-pypi workflow
+          gh workflow run publish-pypi.yml --ref main
+
+          echo "Triggered PyPI publish workflow for v${{ steps.version.outputs.new_version }}"


### PR DESCRIPTION
## Problem

The PyPI publish workflow is configured to trigger on `release: types: [published]` events, but it wasn't being triggered when the version-and-release workflow created releases. This is because GitHub Actions workflows using `GITHUB_TOKEN` don't trigger other workflows (to prevent infinite loops).

As a result:
- Releases v0.2.0, v0.2.1, v0.2.2, and v0.2.3 were created
- But none of them triggered the publish-pypi workflow
- Packages were never published to PyPI

## Solution

This PR adds a step at the end of the version-and-release workflow that manually triggers the publish-pypi workflow using `gh workflow run`. This ensures that after a release is created, the PyPI publish workflow is triggered.

## Changes

- `.github/workflows/version-and-release.yml`: Added "Trigger PyPI Publish Workflow" step

## Testing

After this is merged:
1. The next commit to main will trigger version-and-release
2. Which will create a release
3. And then trigger publish-pypi
4. Which will publish to PyPI

## Note

We may also need to manually trigger the publish workflow for existing releases (v0.2.0 - v0.2.3) to get them published to PyPI.