### PR TITLE
fix: add actions write permission for workflow dispatch

### DIFF
--- a/.github/workflows/version-and-release.yml
+++ b/.github/workflows/version-and-release.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   version-and-release:


### PR DESCRIPTION
## Problem

The version-and-release workflow is failing when trying to trigger the publish-pypi workflow with:
```
HTTP 403: Resource not accessible by integration
```

This is because the workflow needs `actions: write` permission to trigger other workflows using `gh workflow run`.

## Solution

Add `actions: write` to the permissions section of the version-and-release workflow.

## Changes

- `.github/workflows/version-and-release.yml`: Added `actions: write` permission