### PR TITLE
fix: consolidate RTD build steps into commands section

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,16 +9,13 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  jobs:
-    post_create_environment:
-      # Install poetry
-      - pip install poetry
-      # Configure poetry to not create virtualenvs
-      - poetry config virtualenvs.create false
-    post_install:
-      # Install all dependencies including the project itself
-      - poetry install --with docs --no-interaction
   commands:
+    # Install poetry
+    - pip install poetry
+    # Configure poetry to not create virtualenvs
+    - poetry config virtualenvs.create false
+    # Install all dependencies including the project itself
+    - poetry install --with docs --no-interaction
     # Let Poetry run Sphinx to avoid dependency conflicts
     - poetry run sphinx-build -b html docs $READTHEDOCS_OUTPUT/html
 


### PR DESCRIPTION
## Problem

The RTD build is still failing even though we switched to using custom `build.commands`. The issue is that when you specify `build.commands`, Read the Docs runs ONLY those commands and completely skips the normal build process, including the `post_install` jobs.

Our configuration had:
- `jobs.post_install`: Install poetry and dependencies
- `commands`: Run sphinx-build

But RTD was only running the commands, so Poetry wasn't installed.

## Solution

Consolidate ALL build steps into the `commands` section:
1. Install poetry
2. Configure poetry
3. Install dependencies
4. Run sphinx-build

## Changes

- `.readthedocs.yaml`: Moved all installation steps from `jobs` into `commands` section