### PR TITLE
fix(ci): use default semantic-release templates for proper changelog generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,23 +214,8 @@ match = "main"
 prerelease = false
 
 [tool.semantic_release.changelog]
-template_dir = "templates"
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
-
-[tool.semantic_release.changelog.environment]
-block_start_string = "{%"
-block_end_string = "%}"
-variable_start_string = "{{"
-variable_end_string = "}}"
-comment_start_string = "{#"
-comment_end_string = "#}"
-trim_blocks = false
-lstrip_blocks = false
-newline_sequence = "\n"
-keep_trailing_newline = false
-extensions = []
-autoescape = true
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]


### PR DESCRIPTION
## Problem

Release notes are currently showing only empty section headers with no actual content:

```
Release v0.4.0
Features
Bug Fixes
Documentation
...
```

## Root Cause

The `pyproject.toml` semantic-release configuration was pointing to:
```toml
[tool.semantic_release.changelog]
template_dir = "templates"
```

This non-existent templates directory caused python-semantic-release to generate empty sections instead of populating them with commit messages.

## Solution

- Removed `template_dir = "templates"` configuration
- Removed unnecessary `[tool.semantic_release.changelog.environment]` section
- Now uses python-semantic-release default built-in templates

## Expected Result

After this fix, release notes will properly show:

**Features**
- feat(ci): add comprehensive OSS automation and documentation (#76)

**Bug Fixes**
- fix(ci): use default semantic-release templates for proper changelog generation

**Documentation**
- docs(readme): update installation instructions

etc.

## Testing

When this PR is merged, the next release (v0.4.1 patch) will demonstrate the improved changelog format with actual commit details under each section.