### PR TITLE
fix(ci): explicitly configure angular commit parser for semantic-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,6 +208,8 @@ upload_to_pypi = true
 remove_dist = false
 major_on_zero = false
 tag_format = "v{version}"
+commit_parser = "angular"
+logging_use_named_masks = false
 
 [tool.semantic_release.branches.main]
 match = "main"
@@ -218,9 +220,10 @@ changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
 
 [tool.semantic_release.commit_parser_options]
-allowed_tags = ["feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert"]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
+default_bump_level = 0
 
 [tool.semantic_release.remote]
 name = "origin"


### PR DESCRIPTION
## Problem

GitHub releases continue to show empty section headers with no commit details:

```
Release v0.4.1
Features
Bug Fixes   (empty - should show fix commits)
Documentation
...
```

Even though commits like `fix(ci): use default semantic-release templates...` exist between releases.

## Analysis

Between v0.4.0 and v0.4.1, we have:
- `fix(ci): use default semantic-release templates...` (#78) - should appear in Bug Fixes

python-semantic-release is generating the section structure but not populating it with commits.

## Solution

Explicitly configure the Angular commit parser and provide complete configuration:

```toml
commit_parser = "angular"
logging_use_named_masks = false

[tool.semantic_release.commit_parser_options]
allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]
minor_tags = ["feat"]
patch_tags = ["fix", "perf"]
default_bump_level = 0
```

## Expected Result

After merging, v0.4.2 release notes should show:

**Bug Fixes**
- fix(ci): explicitly configure angular commit parser for semantic-release

This will validate that the configuration is working and future releases will have properly populated changelogs.

## Testing

Merge this PR and verify the v0.4.2 release notes contain actual commit messages instead of empty sections.