### PR TITLE
fix(ci): set changelog mode to 'init' to force fresh changelog generation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,7 @@ prerelease = false
 [tool.semantic_release.changelog]
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
+mode = "init"
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]


### PR DESCRIPTION
## Problem

GitHub releases continue to show empty sections even after:
- Removing custom template configuration
- Explicitly setting angular commit parser
- Renaming old CHANGELOG.md

Current releases show structure but no content:


## Root Cause

semantic-release is NOT creating or updating CHANGELOG.md at all:
- No CHANGELOG.md file exists after v0.4.3 release
- GitHub release notes are generated from changelog content
- Empty changelog = empty release notes

## Solution

Add `mode = "init"` to changelog configuration:

```toml
[tool.semantic_release.changelog]
changelog_file = "CHANGELOG.md"
exclude_commit_patterns = []
mode = "init"
```

This forces semantic-release to initialize a fresh changelog from scratch, populating both CHANGELOG.md and GitHub release notes.

## Expected Result

v0.4.4 release will include:
- New CHANGELOG.md file with all commit history
- GitHub release notes with actual commit details under appropriate sections

## Testing

Merge and verify v0.4.4 has populated release notes.