### PR TITLE
feat(ci): use GitHub's automatic release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,52 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - skip-changelog
+    authors:
+      - dependabot
+  categories:
+    - title: Breaking Changes 🚨
+      labels:
+        - breaking-change
+        - breaking
+    - title: Features ✨
+      labels:
+        - feature
+        - enhancement
+        - feat
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+        - fix
+        - bugfix
+    - title: Documentation 📚
+      labels:
+        - documentation
+        - docs
+    - title: Performance Improvements ⚡
+      labels:
+        - performance
+        - perf
+    - title: Code Refactoring 🔨
+      labels:
+        - refactor
+        - refactoring
+    - title: Testing 🧪
+      labels:
+        - test
+        - tests
+    - title: CI/CD & Infrastructure 🔧
+      labels:
+        - ci-cd
+        - ci
+        - cd
+        - github
+        - workflow
+    - title: Chores & Maintenance 🧹
+      labels:
+        - chore
+        - maintenance
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -61,3 +61,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.release.outputs.tag }}
+
+      - name: Generate GitHub release notes
+        if: steps.release.outputs.released == 'true'
+        run: |
+          gh release edit ${{ steps.release.outputs.tag }} --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,8 @@ prerelease = false
 changelog_file = "CHANGELOG.md"
 exclude_commit_patterns = []
 mode = "init"
+# GitHub auto-generates release notes via .github/release.yml
+# CHANGELOG.md is maintained but not used for GitHub releases
 
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "revert", "style", "test"]


### PR DESCRIPTION
## Problem

GitHub releases have shown empty sections through multiple attempts to fix:
- ❌ Removed custom template configuration
- ❌ Explicitly set angular commit parser
- ❌ Renamed old CHANGELOG.md
- ❌ Set changelog mode to 'init'

All releases still show structure but no content:
```
Release v0.4.4
Features
Bug Fixes
Chores     (empty)
```

## Root Cause

We've been fighting python-semantic-release's changelog template system when **GitHub has a built-in automatic release notes feature** that does exactly what we need!

## Solution

Use GitHub's native automatic release notes generation:

1. **Created `.github/release.yml`** - Configures automatic categorization of PRs into sections:
   - Breaking Changes 🚨
   - Features ✨
   - Bug Fixes 🐛
   - Documentation 📚
   - Performance Improvements ⚡
   - Code Refactoring 🔨
   - Testing 🧪
   - CI/CD & Infrastructure 🔧
   - Chores & Maintenance 🧹

2. **Added workflow step** - After semantic-release creates the release, automatically populate it with GitHub-generated notes:
   ```yaml
   - name: Generate GitHub release notes
     run: gh release edit ${{ steps.release.outputs.tag }} --generate-notes
   ```

3. **Leverages existing infrastructure** - Uses labels already applied by our auto-labeler bot to categorize PRs

## How It Works

1. Developer creates PR with conventional commit title (e.g., "feat(parsers): add UUID parser")
2. Auto-labeler bot adds appropriate labels (e.g., "feature", "parsers")
3. PR gets merged to main
4. Semantic-release analyzes commits and creates new version + release
5. **GitHub automatically generates release notes** from PRs since last release
6. Release notes are organized by category based on labels

## Expected Result

v0.5.0 release will show:

```
Release v0.5.0

## Features ✨
- feat(ci): use GitHub's automatic release notes generation (#85)

## Bug Fixes 🐛
- fix(ci): set changelog mode to 'init' to force fresh changelog generation (#84)

## Chores & Maintenance 🧹
- chore: rename old CHANGELOG.md to allow semantic-release to generate fresh changelog (#82)
```

**No more empty sections! 🎉**

## Benefits

- ✅ No changelog template wrestling
- ✅ Leverages GitHub's native functionality
- ✅ Works perfectly with our auto-labeler bot
- ✅ Clean, categorized release notes
- ✅ Includes PR numbers and links automatically
- ✅ Simple, maintainable configuration

## Testing

Merge this PR and verify v0.5.0 has populated, categorized release notes.