### PR TITLE
fix(ci): don't exclude dependencies label from release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,7 +1,6 @@
 changelog:
   exclude:
     labels:
-      - dependencies
       - skip-changelog
     authors:
       - dependabot
@@ -47,6 +46,9 @@ changelog:
       labels:
         - chore
         - maintenance
+    - title: Dependencies 📦
+      labels:
+        - dependencies
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
## Root Cause of Empty Release Notes

Found it! PR #86 has the `dependencies` label (because it modified pyproject.toml), and in `.github/release.yml` we were **excluding** all PRs with that label:

```yaml
exclude:
  labels:
    - dependencies  # ← This excluded PR #86!
```

So GitHub's auto-generated release notes skipped PR #86 entirely, showing only the version bump commit.

## Solution

- Remove `dependencies` from the exclude list
- Add `Dependencies 📦` category to group dependency updates
- Dependabot PRs still excluded via author filter

## Testing

After merging, I'll manually regenerate v0.5.0's release notes to verify the fix works.

## Expected Result

v0.5.0 release notes will show:

```
Features ✨
- feat(ci): use GitHub's automatic release notes generation (#86)

Dependencies 📦
- (any dependency update PRs)
```