### PR TITLE
fix(ci): disable upload_to_vcs_release to prevent semantic-release from creating releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,4 +235,4 @@ ignore_token_for_push = false
 
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
-upload_to_vcs_release = true
+upload_to_vcs_release = false


### PR DESCRIPTION
## The ACTUAL Final Piece!

Even after setting `upload_to_release = false`, semantic-release was STILL creating GitHub releases (with empty template notes) because:

```toml
[tool.semantic_release.publish]
upload_to_vcs_release = true  # ← This was the culprit!
```

## Proof It Works

I manually deleted and recreated v0.5.2 using:
```bash
gh release create v0.5.2 --generate-notes
```

**Result:** https://github.com/mikelane/valid8r/releases/tag/v0.5.2

The release now shows:
- ✅ PR #90 under "CI/CD & Infrastructure 🔧"
- ✅ Version bump under "Other Changes"
- ✅ Full changelog link

**ACTUAL CONTENT!** 🎉

## This PR

Sets `upload_to_vcs_release = false` so semantic-release will ONLY handle versioning and tagging, letting our workflow create the release with proper auto-generated notes.

## Expected Result

v0.5.3 will be the FIRST release created entirely by our new workflow with properly populated release notes from the start!