### PR TITLE
fix(ci): explicitly set vcs_release=false in action inputs

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -47,6 +47,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
+          vcs_release: false
 
       - name: Create GitHub Release with auto-generated notes
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## The REAL Final Piece (I hope!)

Even after setting `upload_to_vcs_release = false` in pyproject.toml, releases were STILL being created with empty notes because:

**The python-semantic-release GitHub Action has its own input parameters that DEFAULT to true and OVERRIDE pyproject.toml settings!**

### The Timeline
```
Workflow starts
  ↓
python-semantic-release action runs
  ├─ Uses vcs_release input (defaults to TRUE)
  ├─ IGNORES our pyproject.toml upload_to_vcs_release=false
  ├─ Creates GitHub release with empty template notes
  └─ Sets released='false' (release already exists)
  ↓
Our 'Create GitHub Release' step SKIPPED (released != 'true')
  ↓
Empty release notes 😭
```

### The Fix

Add explicit action input:
```yaml
- name: Python Semantic Release
  uses: python-semantic-release/python-semantic-release@v9.21.1
  with:
    vcs_release: false  # ← Explicitly disable VCS release creation
```

### Expected Result

v0.5.4 should FINALLY:
1. ✅ semantic-release does NOT create release (vcs_release: false)
2. ✅ semantic-release sets released='true' (first run, did create tag/version)
3. ✅ Our workflow step runs (condition met!)
4. ✅ `gh release create --generate-notes` creates release WITH CONTENT
5. ✅ Release notes show actual PRs categorized properly

**THIS HAS TO WORK!**