### PR TITLE
fix: populate GitHub release notes with auto-generated content

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -47,14 +47,19 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
-          vcs_release: false
 
-      - name: Create GitHub Release with auto-generated notes
+      - name: Update release notes with auto-generated content
         if: steps.release.outputs.released == 'true'
         run: |
-          gh release create ${{ steps.release.outputs.tag }} \
-            --title "Release ${{ steps.release.outputs.tag }}" \
-            --generate-notes \
+          # Generate release notes using GitHub's API
+          NOTES=$(gh api repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name=${{ steps.release.outputs.tag }} \
+            -f target_commitish=main \
+            --jq '.body')
+
+          # Update the existing release with the generated notes and add artifacts
+          echo "$NOTES" | gh release edit ${{ steps.release.outputs.tag }} \
+            --notes-file - \
             dist/*
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,7 @@ version_toml = ["pyproject.toml:tool.poetry.version"]
 branch = "main"
 build_command = "pip install poetry && poetry build"
 dist_path = "dist/"
-upload_to_release = false
+upload_to_release = true
 upload_to_pypi = false
 remove_dist = false
 major_on_zero = false
@@ -235,4 +235,4 @@ ignore_token_for_push = false
 
 [tool.semantic_release.publish]
 dist_glob_patterns = ["dist/*"]
-upload_to_vcs_release = false
+upload_to_vcs_release = true


### PR DESCRIPTION
## Summary

Fixes the empty GitHub release notes issue that has plagued releases v0.4.0 through v0.5.3.

## Changes

This PR implements a new strategy for generating release notes:

1. **Let semantic-release create releases** - Removed all attempts to prevent release creation (`vcs_release: false`, `upload_to_release: false`, etc.)
2. **Update releases immediately** - Added a workflow step that runs after semantic-release and:
   - Uses GitHub's `generate-notes` API to create properly categorized release notes
   - Edits the existing release with the generated notes
   - Adds distribution artifacts to the release

## Technical Details

### Workflow Changes (.github/workflows/semantic-release.yml)
- Removed `vcs_release: false` parameter that was preventing releases
- Replaced "Create GitHub Release" step with "Update release notes" step
- New step uses `gh api repos/.../releases/generate-notes` to generate notes
- Uses `gh release edit` to update the existing release

### Configuration Changes (pyproject.toml)
- Set `upload_to_release = true` (was `false`)
- Set `upload_to_vcs_release = true` (was `false`)

## Why This Approach

Previous attempts tried to prevent semantic-release from creating releases and create them manually with `--generate-notes`. However, this created a race condition where:
- When semantic-release created a release, it used empty template notes
- When we prevented semantic-release from creating releases, the `released` output was false, preventing our manual creation step from running

The new approach stops fighting semantic-release and instead leverages GitHub's release notes API to update releases after creation.

## Testing

This fix will be validated when the PR is merged to main and triggers the semantic-release workflow. The resulting release should have properly categorized notes based on `.github/release.yml` configuration.