### PR TITLE
chore: add Codecov configuration for coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,30 @@
+# Codecov configuration for valid8r
+# https://docs.codecov.com/docs/codecov-yaml
+
+coverage:
+  status:
+    project:
+      default:
+        target: 90%  # Target 90% overall coverage
+        threshold: 2%  # Allow 2% drop before failing
+    patch:
+      default:
+        target: 80%  # New code should have 80%+ coverage
+        threshold: 5%
+
+  precision: 2
+  round: down
+  range: 80..100  # Green zone starts at 80%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default  # Post comment on every PR
+  require_changes: false
+
+ignore:
+  - "tests/**"
+  - "docs/**"
+  - "scripts/**"
+  - "smoke_test.py"
+  - "**/__init__.py"
+  - "**/conftest.py"


### PR DESCRIPTION
## Summary

Adds `.codecov.yml` configuration to fix the Codecov badge and enable proper coverage reporting in CI.

## Changes

- **`.codecov.yml`**: Added Codecov configuration with:
  - 90% project coverage requirement
  - 80% patch coverage requirement for new code
  - Informational PR comments with coverage diffs
  - Ignore patterns for tests and documentation
  - Quality gates to ensure new code is well-tested

## Prerequisites

✅ **`CODECOV_TOKEN`** secret has been added to GitHub repository settings

## Verification

Once merged, the Codecov badge in README.md will display the current coverage (92%).

## Related

Fixes the non-functional Codecov badge reported by the user.