### PR TITLE
fix(ci): configure PAT to bypass branch protection in semantic-release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          persist-credentials: false
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -51,7 +51,7 @@ jobs:
         id: release
         uses: python-semantic-release/python-semantic-release@v9.21.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
           git_committer_name: "github-actions[bot]"
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
           # Build already completed, so skip it in PSR


### PR DESCRIPTION
## Problem

The semantic-release workflow is failing with branch protection violations:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

The default `GITHUB_TOKEN` does not have permissions to bypass branch protection rules, even for automated version bumps.

## Solution

Configure the workflow to use `SEMANTIC_RELEASE_TOKEN` (a Classic PAT with `repo` scope) which has bypass permissions.

### Changes Made

1. **Checkout step** (line 26):
   - Changed from: `persist-credentials: false`
   - Changed to: `token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}`

2. **Python Semantic Release step** (line 54):
   - Changed from: `github_token: ${{ secrets.GITHUB_TOKEN }}`
   - Changed to: `github_token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}`

### Prerequisites (Already Configured)

- ✅ Repository ruleset updated: Repository admin can bypass
- ✅ Classic PAT created with `repo` scope
- ✅ Secret added: `SEMANTIC_RELEASE_TOKEN`

## Testing

Once merged, the workflow will:
1. ✅ Analyze commits and calculate version (0.9.1 expected)
2. ✅ Update pyproject.toml and CHANGELOG.md
3. ✅ Commit changes using PAT (bypasses branch protection)
4. ✅ Create git tag v0.9.1
5. ✅ Push to main (allowed via bypass)
6. ✅ Publish to PyPI

## Risk Level

**LOW** - Single configuration change, well-tested pattern, easy rollback.

Closes the semantic-release issue from PR #138.