### PR TITLE
docs: add schema to documentation table of contents (#205)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -136,6 +136,7 @@ Contents
    user_guide/parsers
    user_guide/type_adapters
    user_guide/validators
+   user_guide/schema
    user_guide/error_handling
    user_guide/prompting
    user_guide/advanced_usage


### PR DESCRIPTION
Closes #205

## Summary

The schema documentation file (`docs/user_guide/schema.rst`) exists but was not included in the documentation navigation TOC, making it invisible to users browsing the rendered documentation.

## Changes

- Added `user_guide/schema` to the User Guide toctree in `docs/index.rst`
- Positioned after `user_guide/validators` and before `user_guide/error_handling` for logical flow

## Verification

- Documentation builds successfully with no new errors or warnings
- Schema page now appears in navigation TOC
- All pre-commit hooks pass