### PR TITLE
fix: repair env_example.py for environment variable integration

### DIFF
--- a/examples/env_example.py
+++ b/examples/env_example.py
@@ -130,12 +130,13 @@ def example_nested_config() -> int:
     )
 
     # Main schema with nested configs
+    # Note: For nested schemas, parser must be None
     app_schema = EnvSchema(
         fields={
             'port': EnvField(parser=parse_int, default=8080),
             'debug': EnvField(parser=parse_bool, default=False),
-            'database': EnvField(nested=database_schema),
-            'cache': EnvField(nested=cache_schema),
+            'database': EnvField(parser=None, nested=database_schema),
+            'cache': EnvField(parser=None, nested=cache_schema),
         }
     )
 


### PR DESCRIPTION
Closes #207

## Summary
Fixed broken `env_example.py` that was preventing users from learning environment variable integration. Example 2 (Nested Configuration) was throwing a TypeError due to missing required `parser` parameter.

## Root Cause
The `EnvField` dataclass requires `parser` as the first positional argument. When using nested schemas, the parser should be explicitly set to `None`, but this was omitted in the example code.

## Changes
- Added `parser=None` parameter to nested `EnvField` instances in Example 2
- Added clarifying comment explaining that parser must be `None` for nested schemas
- Verified all 6 examples run successfully with appropriate environment variables

## Testing
```bash
# Test without environment variables (expected behavior - some fail gracefully)
python examples/env_example.py

# Test with all required environment variables (all 6 examples pass)
export APP_DATABASE_URL=postgresql://localhost/mydb
export APP_ADMIN_EMAIL=admin@example.com
export APP_SECRET_KEY=dev-secret
export API_DATABASE_URL=postgresql://localhost/myapp
export API_SECRET_KEY=dev-secret-key
export API_ADMIN_EMAIL=admin@example.com
python examples/env_example.py
# Result: Examples run: 6, Successful: 6, Failed: 0
```

## Before
```
Example 2: Nested Configuration
============================================================
❌ Example failed with exception: EnvField.__init__() missing 1 required positional argument: 'parser'
```

## After
```
Example 2: Nested Configuration
============================================================
✅ Nested configuration loaded successfully:
   App Port: 8080
   App Debug: False

   Database Configuration:
     Host: localhost
     Port: 5432
     Name: myapp
     User: postgres

   Cache Configuration:
     Host: localhost
     Port: 6379
     TTL: 3600s
```

## Impact
- Users can now run the environment variable integration example without errors
- Clarifies the API requirement that nested schemas require `parser=None`
- Improves learning experience for the environment variable integration feature