### PR TITLE
docs: add performance benchmarking section to README (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ print(f"Your age is {age}")
 
 **Interactive Prompts**: Built-in user input prompting with automatic retry and validation.
 
+**High Performance**: Valid8r is [4-300x faster than Pydantic](docs/performance.md) for basic parsing, making it ideal for high-throughput APIs and batch processing.
+
+## Performance
+
+Valid8r is designed for high-performance validation with minimal overhead:
+
+| Scenario | valid8r | Pydantic | Speedup |
+|----------|---------|----------|---------|
+| Integer parsing | 375ns | 102µs | **273x faster** |
+| Nested objects | 37µs | 568µs | **15x faster** |
+| List (100 items) | 30µs | 126µs | **4x faster** |
+
+**When to use valid8r**:
+- High-throughput APIs (>5K requests/sec)
+- Batch processing pipelines
+- CLI tools requiring structured parsing
+- Performance-critical code paths
+
+**When to use Pydantic**:
+- FastAPI applications (tight integration)
+- Complex data models with auto-schema generation
+- Developer experience > raw performance
+
+**Full benchmarks and methodology**: [docs/performance.md](docs/performance.md)
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
## Summary

Completes #217 by adding a comprehensive performance section to the README, making valid8r's performance characteristics immediately visible to users evaluating the library.

## What Was Done

### README Updates
- Added "Performance" section after "Why Valid8r?" with comparison table
- Highlighted 4-300x speedup vs Pydantic for key scenarios
- Clear guidance on when to use valid8r vs Pydantic
- Link to full benchmarks at `docs/performance.md`

### Infrastructure Already Complete

Investigation revealed that **all benchmark infrastructure was already production-ready**:

**Benchmark Scenarios** (`benchmarks/scenarios.py`):
- Integer parsing, email/URL validation, nested objects, list validation
- Both success and failure cases for fair comparison

**Comprehensive Testing** (`tests/benchmarks/`):
- pytest-benchmark tests for all scenarios
- Correctness tests ensuring all libraries produce identical results
- Determinism tests for repeatable results

**Complete Documentation**:
- `docs/performance.md` - Full performance analysis with methodology
- `benchmarks/README.md` - Usage guide and reproducibility instructions

**CI/CD** (`.github/workflows/benchmarks.yml`):
- Automated benchmark runs on PRs
- Multi-Python version testing (3.11, 3.12, 3.13)
- Weekly scheduled runs
- Result artifacts and PR comments

## Testing

- ✅ All pre-commit hooks pass
- ✅ Benchmark correctness tests pass (14/14)
- ✅ Sample benchmarks execute successfully
- ✅ Documentation builds without errors

## Documentation Updates

- [x] README.md updated with performance section
- [x] Links to docs/performance.md (already comprehensive)
- [x] Pre-commit hooks verified
- [x] Docs build successfully

## Related Issues

Closes #217