### PR TITLE
docs: Fix async documentation contradictions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,15 +246,44 @@ Valid8r aims to become the go-to validation library for Python applications by:
 
 ---
 
+## Async Validation ✅ COMPLETED
+
+**Goal**: Enable non-blocking validation for I/O-bound operations
+
+### Async Validators Module
+- [x] `valid8r.async_validators` module with comprehensive async validation support
+  - `unique_in_db()` - Database uniqueness validation
+  - `exists_in_db()` - Foreign key validation
+  - `all_of()` - Parallel AND composition
+  - `any_of()` - Parallel OR composition
+  - `sequence()` - Sequential composition with data transformation
+  - `RateLimitedValidator` - Token bucket rate limiting for external APIs
+  - `RetryingValidator` - Exponential backoff retry logic
+
+### Schema Async Support
+- [x] `Schema.validate_async()` method for async validation workflows
+  - Concurrent execution of async validators across fields
+  - Mixed sync/async validators (sync runs first for fail-fast behavior)
+  - Configurable timeout support
+  - Full error accumulation across all fields
+
+### Documentation
+- [x] Comprehensive async validation user guide (`docs/user_guide/async_validation.rst`)
+- [x] Async validators guide (`docs/guides/async-validators.md`)
+- [x] FastAPI async validation integration guide (`docs/guides/fastapi-async-validation.md`)
+
+**Deliverable**: ✅ Full async validation support for database checks, API calls, and I/O-bound operations
+
+---
+
 ## Future Considerations (Post-1.0)
 
 ### Potential Features
-- **Async validation**: Support for async validators (API calls, database lookups)
 - **Localization**: Multi-language error messages
 - **GraphQL integration**: Schema validation for GraphQL APIs
 - **OpenAPI integration**: Generate validators from OpenAPI specs
 - **Performance**: Compiled validators using Cython or Rust extensions
-- **Web frameworks**: FastAPI, Flask, Django integration helpers
+- **Web frameworks**: Flask, Django integration helpers (FastAPI guide already available)
 
 ### Community Requests
 Feature requests and priorities will evolve based on community feedback. Issues labeled `enhancement` are candidates for future roadmap inclusion.
@@ -282,7 +311,7 @@ See [CLAUDE.md](./CLAUDE.md) for development workflow and [CONTRIBUTING.md](./CO
 
 ---
 
-*Last Updated: 2025-11-16*
-*Current Version: 1.15.0*
+*Last Updated: 2026-01-21*
+*Current Version: 1.27.0*
 *v1.0 Released: 2025-11-06*
 *Next Major Milestone: v2.0 (RFC-001 Complete - Estimated Q1 2026)*

--- a/docs/guides/fastapi-async-validation.md
+++ b/docs/guides/fastapi-async-validation.md
@@ -605,15 +605,28 @@ def validate_email(email: str) -> bool:
 
 **Async Validation (For I/O-bound operations)**:
 ```python
-from valid8r.async_validation import validate_async
+from valid8r.core import schema, parsers
+from valid8r.core.maybe import Maybe
+
+async def check_mx_record(email: str) -> Maybe[str]:
+    """Check if email domain has valid MX records."""
+    # Simulate MX record lookup (replace with actual DNS query)
+    import asyncio
+    await asyncio.sleep(0.05)  # Network I/O
+    return Maybe.success(email)
+
+# Define schema with async validator
+email_schema = schema.Schema(fields={
+    'email': schema.Field(
+        parser=parsers.parse_email,
+        validators=[check_mx_record],  # Async validator
+        required=True
+    ),
+})
 
 async def validate_email_with_mx_check(email: str) -> bool:
     """Async validation with MX record lookup."""
-    result = await validate_async(
-        parsers.parse_email,
-        email,
-        check_mx_record=True  # I/O-bound operation
-    )
+    result = await email_schema.validate_async({'email': email})
     return result.is_success()
 
 # Benchmark: ~50-100 milliseconds (network latency)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -143,6 +143,7 @@ Contents
    user_guide/type_adapters
    user_guide/validators
    user_guide/schema
+   user_guide/async_validation
    user_guide/error_handling
    user_guide/prompting
    user_guide/advanced_usage


### PR DESCRIPTION
## Summary

Fixes documentation contradictions about async support identified in #272.

**Problem**: The ROADMAP.md listed async validation as a "Future Consideration" but the library has fully implemented async validation support via:
- `valid8r.async_validators` module
- `Schema.validate_async()` method
- Comprehensive user guide in `docs/user_guide/async_validation.rst`

**Changes**:
- Updated ROADMAP.md to properly document async validation as a COMPLETED feature
- Fixed incorrect import path in `docs/guides/fastapi-async-validation.md` (was `from valid8r.async_validation import validate_async` which doesn't exist)
- Added `async_validation` to the User Guide toctree in `docs/index.rst`

## Audit Findings

**Option A Confirmed: Async IS fully supported**

The async validation feature is complete with:
- `unique_in_db()` - Database uniqueness validation
- `exists_in_db()` - Foreign key validation
- `all_of()` - Parallel AND composition
- `any_of()` - Parallel OR composition
- `sequence()` - Sequential composition
- `RateLimitedValidator` - Token bucket rate limiting
- `RetryingValidator` - Exponential backoff retry logic

## Test plan
- [x] Docs build successfully (`uv run tox -e docs`)
- [x] All unit tests pass (951 passed)
- [x] Pre-commit hooks pass

## Documentation Updates
- [x] ROADMAP.md updated to reflect completed async feature
- [x] Fixed broken import in fastapi-async-validation.md
- [x] Added async_validation to docs toctree

Closes #272