### PR TITLE
feat: Add Success and Failure as top-level exports

### DIFF
--- a/tests/unit/test_public_api.py
+++ b/tests/unit/test_public_api.py
@@ -22,6 +22,51 @@ class DescribePublicApi:
 
         assert Maybe is CoreMaybe
 
+    def it_imports_success_from_top_level(self) -> None:
+        # Scenario: Import Success from top-level for pattern matching
+        from valid8r import Success
+        from valid8r.core.maybe import Success as CoreSuccess
+
+        assert Success is CoreSuccess
+
+    def it_imports_failure_from_top_level(self) -> None:
+        # Scenario: Import Failure from top-level for pattern matching
+        from valid8r import Failure
+        from valid8r.core.maybe import Failure as CoreFailure
+
+        assert Failure is CoreFailure
+
+    def it_enables_pattern_matching_with_top_level_imports(self) -> None:
+        # Scenario: Pattern matching works with top-level Success/Failure imports
+        from valid8r import (
+            Failure,
+            Maybe,
+            Success,
+        )
+
+        success_result: Maybe[int] = Success(42)
+        failure_result: Maybe[int] = Failure('error')
+
+        # Verify pattern matching works
+        match success_result:
+            case Success(value):
+                assert value == 42
+            case Failure(_):
+                raise AssertionError('Expected Success')
+
+        match failure_result:
+            case Success(_):
+                raise AssertionError('Expected Failure')
+            case Failure(error):
+                assert error == 'error'
+
+    def it_includes_success_and_failure_in_all(self) -> None:
+        # Scenario: __all__ includes Success and Failure
+        import valid8r
+
+        assert 'Success' in valid8r.__all__
+        assert 'Failure' in valid8r.__all__
+
     def it_exposes_prompt_ask_at_top_level(self) -> None:
         # Scenario: Top-level ask function
         from valid8r import prompt

--- a/valid8r/__init__.py
+++ b/valid8r/__init__.py
@@ -21,7 +21,11 @@ from .core.errors import (
     ErrorCode,
     ValidationError,
 )
-from .core.maybe import Maybe
+from .core.maybe import (
+    Failure,
+    Maybe,
+    Success,
+)
 from .core.parsers import (
     EmailAddress,
     PhoneNumber,
@@ -38,10 +42,12 @@ from .core.type_adapters import from_type
 __all__ = [
     'EmailAddress',
     'ErrorCode',
+    'Failure',
     'Field',
     'Maybe',
     'PhoneNumber',
     'Schema',
+    'Success',
     'UrlParts',
     'ValidationError',
     '__version__',


### PR DESCRIPTION
Closes #270

## Summary

Add `Success` and `Failure` types as top-level exports in `valid8r/__init__.py`, enabling pattern matching with concise imports.

## Changes

- Export `Success` and `Failure` from `valid8r.core.maybe` at the top level
- Update `__all__` to include both types
- Add comprehensive tests for new imports

## Usage

**Before (still works for backward compatibility):**
```python
from valid8r.core.maybe import Success, Failure
```

**After (new, recommended):**
```python
from valid8r import Success, Failure, Maybe

result = parse_int("42")
match result:
    case Success(value):
        print(f"Got {value}")
    case Failure(error):
        print(f"Error: {error}")
```

## Documentation Updates

- [x] No docstring changes needed (classes already documented in `valid8r.core.maybe`)
- [x] No user guide changes needed (this is a convenience export)
- [x] No API docs changes needed (auto-generated from existing docstrings)
- [x] Examples updated to use top-level imports (not applicable - docs handled by #272)
- [x] README.md update not needed (minimal change)
- [x] CHANGELOG.md entry (via conventional commit)
- [x] Docs build verified: Not running separately (existing docs will pick up exports)

## Test Plan

- [x] New tests added to `tests/unit/test_public_api.py`:
  - `it_imports_success_from_top_level`
  - `it_imports_failure_from_top_level`
  - `it_enables_pattern_matching_with_top_level_imports`
  - `it_includes_success_and_failure_in_all`
- [x] Full tox test suite passes (py311, py312, py313, py314)
- [x] Backward compatibility verified (deep imports still work)