### PR TITLE
chore: remove unused noqa directives

### DIFF
--- a/tests/bdd/steps/cli_starter_template_steps.py
+++ b/tests/bdd/steps/cli_starter_template_steps.py
@@ -63,7 +63,7 @@ def step_run_cli_with_invalid_arguments(context: Context) -> None:
     cli_script = ctx.template_path / 'cli.py'
 
     # Run the CLI with invalid arguments (e.g., invalid user age)
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, str(cli_script), 'add-user', '--name', 'John', '--age', 'not-a-number'],
         check=False,
         capture_output=True,
@@ -134,7 +134,7 @@ def step_run_cli_in_interactive_mode(context: Context) -> None:
 
     # Run the CLI in interactive mode with invalid then valid inputs
     # Simulating: invalid age "twenty", then valid age "25"
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, str(cli_script), 'add-user', '--interactive'],
         check=False,
         input='John Doe\ntwenty\n25\njohn@example.com\n',
@@ -229,7 +229,7 @@ def step_cli_loads_configuration(context: Context) -> None:
 
     cli_script = ctx.template_path / 'cli.py'
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, str(cli_script), 'load-config', '--file', str(ctx.config_file_path)],
         check=False,
         capture_output=True,
@@ -413,7 +413,7 @@ def step_run_tests_successfully(context: Context) -> None:
     assert len(test_files) > 0, 'No test files found in tests directory'
 
     # Run the tests
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, '-m', 'pytest', 'tests', '-v'],
         check=False,
         capture_output=True,
@@ -437,7 +437,7 @@ def step_build_project_without_errors(context: Context) -> None:
     # Try to import the main CLI module (syntax check)
     cli_file = ctx.template_path / 'cli.py'
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, '-m', 'py_compile', str(cli_file)],
         check=False,
         capture_output=True,
@@ -449,7 +449,7 @@ def step_build_project_without_errors(context: Context) -> None:
     # Try to compile validators module
     validators_file = ctx.template_path / 'validators.py'
 
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, '-m', 'py_compile', str(validators_file)],
         check=False,
         capture_output=True,

--- a/tests/bdd/steps/rich_integration_steps.py
+++ b/tests/bdd/steps/rich_integration_steps.py
@@ -340,7 +340,7 @@ def _run_example_scenario(context: Context, scenario: str, stdin: str | None = N
         raise AssertionError(msg)
 
     # Run the example
-    result = subprocess.run(  # noqa: S603
+    result = subprocess.run(
         [sys.executable, str(example_path), f'--scenario={scenario}'],
         check=False,
         capture_output=True,

--- a/tests/bdd/steps/typer_steps.py
+++ b/tests/bdd/steps/typer_steps.py
@@ -455,7 +455,7 @@ def _run_cli(context: Context, args: list[str]) -> None:
 
     try:
         # Run the CLI as a subprocess
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, cli_file, *args],
             check=False,
             capture_output=True,

--- a/tests/unit/examples/test_rich_integration.py
+++ b/tests/unit/examples/test_rich_integration.py
@@ -27,7 +27,7 @@ class DescribeProjectWizard:
 
     def it_accepts_scenario_argument(self, example_path: Path) -> None:
         """The example accepts --scenario command-line argument."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=success'],
             check=False,
             capture_output=True,
@@ -39,7 +39,7 @@ class DescribeProjectWizard:
 
     def it_runs_success_scenario(self, example_path: Path) -> None:
         """The success scenario runs and produces output."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=success'],
             check=False,
             capture_output=True,
@@ -51,7 +51,7 @@ class DescribeProjectWizard:
 
     def it_runs_failure_scenario(self, example_path: Path) -> None:
         """The failure scenario runs and produces output."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=failure'],
             check=False,
             capture_output=True,
@@ -63,7 +63,7 @@ class DescribeProjectWizard:
 
     def it_runs_batch_scenario(self, example_path: Path) -> None:
         """The batch scenario runs and produces output."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=batch'],
             check=False,
             capture_output=True,
@@ -75,7 +75,7 @@ class DescribeProjectWizard:
 
     def it_runs_interactive_scenario(self, example_path: Path) -> None:
         """The interactive scenario runs with stdin input."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=interactive'],
             check=False,
             capture_output=True,
@@ -97,7 +97,7 @@ class DescribeRichStyling:
 
     def it_uses_ansi_color_codes(self, example_path: Path) -> None:
         """The example output contains ANSI color codes."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=success'],
             check=False,
             capture_output=True,
@@ -109,7 +109,7 @@ class DescribeRichStyling:
 
     def it_uses_box_drawing_characters(self, example_path: Path) -> None:
         """The example output contains box drawing characters (panels/tables)."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=success'],
             check=False,
             capture_output=True,
@@ -123,7 +123,7 @@ class DescribeRichStyling:
 
     def it_shows_success_indicators(self, example_path: Path) -> None:
         """The success scenario shows success indicators."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=success'],
             check=False,
             capture_output=True,
@@ -137,7 +137,7 @@ class DescribeRichStyling:
 
     def it_shows_error_indicators_on_failure(self, example_path: Path) -> None:
         """The failure scenario shows error indicators."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=failure'],
             check=False,
             capture_output=True,
@@ -151,7 +151,7 @@ class DescribeRichStyling:
 
     def it_shows_progress_indicators_in_batch(self, example_path: Path) -> None:
         """The batch scenario shows progress indicators."""
-        result = subprocess.run(  # noqa: S603
+        result = subprocess.run(
             [sys.executable, str(example_path), '--scenario=batch'],
             check=False,
             capture_output=True,


### PR DESCRIPTION
## Summary

Removes 18 unused `noqa: S603` directives that were flagging `subprocess.run()` calls. The S603 security rule is not enabled in ruff, making these suppressions unnecessary.

## Changes

Files cleaned up:
- `tests/bdd/steps/cli_starter_template_steps.py`
- `tests/bdd/steps/rich_integration_steps.py`
- `tests/bdd/steps/typer_steps.py`
- `tests/unit/examples/test_rich_integration.py`

## Test Plan

- [x] All unit tests pass (951)
- [x] Pre-commit hooks pass (ruff check, ruff format)

## Documentation Updates
- [x] No documentation changes needed (code cleanup only)